### PR TITLE
feat: add no-results empty state with recovery actions

### DIFF
--- a/assets/css/wf-shop.css
+++ b/assets/css/wf-shop.css
@@ -118,6 +118,34 @@
   margin-top: 28px;
 }
 
+.wf-no-results {
+  border: 1px solid #dbe5ee;
+  border-radius: 10px;
+  background: #f8fbfe;
+  padding: 32px 20px;
+  text-align: center;
+  margin-top: 12px;
+}
+
+.wf-no-results h3 {
+  margin: 0 0 8px;
+  font-size: 24px;
+  color: #1f2937;
+}
+
+.wf-no-results p {
+  margin: 0;
+  color: #4b5563;
+}
+
+.wf-empty-actions {
+  display: inline-flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 10px;
+  margin-top: 18px;
+}
+
 .wf-active-filters {
   margin-bottom: 16px;
   padding: 10px;

--- a/assets/js/wf-shop.js
+++ b/assets/js/wf-shop.js
@@ -223,7 +223,7 @@
       return;
     }
 
-    var allowedArea = link.closest('.woocommerce-pagination, .wf-per-page, .wf-active-filters, .wf-actions');
+    var allowedArea = link.closest('.woocommerce-pagination, .wf-per-page, .wf-active-filters, .wf-actions, .wf-empty-actions');
     if (!allowedArea) {
       return;
     }

--- a/src/ShopFilters.php
+++ b/src/ShopFilters.php
@@ -66,6 +66,9 @@ final class ShopFilters {
 
 		add_filter( 'loop_shop_columns', array( $this, 'filter_loop_columns' ) );
 		add_filter( 'loop_shop_per_page', array( $this, 'filter_loop_per_page' ), 20 );
+
+		remove_action( 'woocommerce_no_products_found', 'wc_no_products_found', 10 );
+		add_action( 'woocommerce_no_products_found', array( $this, 'render_no_products_state' ), 10 );
 	}
 
 	/**
@@ -252,6 +255,26 @@ final class ShopFilters {
 		}
 
 		echo '</section>';
+		echo '</div>';
+	}
+
+	/**
+	 * Render no-results empty state.
+	 *
+	 * @return void
+	 */
+	public function render_no_products_state(): void {
+		if ( ! $this->is_shop_archive() ) {
+			return;
+		}
+
+		echo '<div class="wf-no-results" role="status" aria-live="polite">';
+		echo '<h3>' . esc_html__( 'No products found', 'woo-filters' ) . '</h3>';
+		echo '<p>' . esc_html__( 'Try removing or changing some filters to find matching products.', 'woo-filters' ) . '</p>';
+		echo '<div class="wf-empty-actions">';
+		echo '<a class="button alt" href="' . esc_url( $this->build_clear_filters_url() ) . '">' . esc_html__( 'Clear all filters', 'woo-filters' ) . '</a>';
+		echo '<a class="button" href="' . esc_url( $this->get_shop_page_url() ) . '">' . esc_html__( 'Back to shop', 'woo-filters' ) . '</a>';
+		echo '</div>';
 		echo '</div>';
 	}
 
@@ -864,6 +887,15 @@ final class ShopFilters {
 			}
 		}
 
+		return wc_get_page_permalink( 'shop' );
+	}
+
+	/**
+	 * Get default shop page URL.
+	 *
+	 * @return string
+	 */
+	private function get_shop_page_url(): string {
 		return wc_get_page_permalink( 'shop' );
 	}
 


### PR DESCRIPTION
## Summary
Implements Issue #2 by adding a dedicated no-results empty state on WooCommerce shop/taxonomy archives, including clear recovery actions and AJAX compatibility.

## Problem
When filters return zero products, users currently get poor recovery guidance. This reduces task completion and increases abandonment.

## Scope
- Replace default WooCommerce no-products renderer with plugin-specific empty state
- Add two recovery actions:
  - **Clear all filters** (preserves non-filter query args)
  - **Back to shop** (returns to canonical shop archive)
- Add empty-state visual styling aligned with existing plugin design language
- Extend AJAX click interception to include empty-state action links

## Out of Scope
- Live filter counts
- Mobile off-canvas drawer
- Admin settings screen

## Acceptance Criteria Mapping
- Empty state appears only when product results are zero via `woocommerce_no_products_found`
- Recovery actions work in AJAX mode and full reload fallback
- Empty-state layout is visually consistent and responsive

## Implementation Notes
- Hook override:
  - remove `wc_no_products_found`
  - register `ShopFilters::render_no_products_state()`
- URL behavior:
  - `build_clear_filters_url()` clears filter keys and preserves compatible query params
  - `get_shop_page_url()` routes to shop root
- AJAX compatibility:
  - Added `.wf-empty-actions` to intercepted link container selectors

## Validation
- `php -l src/ShopFilters.php` passed
- Verified code paths for AJAX and non-JS fallback behavior

## Risks / Mitigations
- Risk: overriding default no-products hook could conflict with theme overrides
- Mitigation: scope is limited to plugin-managed shop archives and uses standard Woo hook lifecycle

Fixes #2