### PR TITLE
feat: add top active-filter bar with removable chips

### DIFF
--- a/assets/css/wf-shop.css
+++ b/assets/css/wf-shop.css
@@ -154,6 +154,14 @@
   background: #f8fbfe;
 }
 
+.wf-top-active-filters {
+  margin: 0 0 14px;
+  padding: 10px;
+  border: 1px solid #dbe5ee;
+  border-radius: 8px;
+  background: #f8fbfe;
+}
+
 .wf-active-filters h5 {
   margin: 0 0 8px;
   font-size: 13px;

--- a/assets/js/wf-shop.js
+++ b/assets/js/wf-shop.js
@@ -223,7 +223,7 @@
       return;
     }
 
-    var allowedArea = link.closest('.woocommerce-pagination, .wf-per-page, .wf-active-filters, .wf-actions, .wf-empty-actions');
+    var allowedArea = link.closest('.woocommerce-pagination, .wf-per-page, .wf-active-filters, .wf-top-active-filters, .wf-actions, .wf-empty-actions');
     if (!allowedArea) {
       return;
     }

--- a/src/ShopFilters.php
+++ b/src/ShopFilters.php
@@ -62,6 +62,7 @@ final class ShopFilters {
 
 		add_action( 'woocommerce_before_main_content', array( $this, 'render_layout_start' ), 15 );
 		add_action( 'woocommerce_after_main_content', array( $this, 'render_layout_end' ), 5 );
+		add_action( 'woocommerce_before_shop_loop', array( $this, 'render_top_active_filters' ), 20 );
 		add_action( 'woocommerce_before_shop_loop', array( $this, 'render_per_page_switcher' ), 25 );
 
 		add_filter( 'loop_shop_columns', array( $this, 'filter_loop_columns' ) );
@@ -279,6 +280,31 @@ final class ShopFilters {
 	}
 
 	/**
+	 * Render top active filters bar above product loop.
+	 *
+	 * @return void
+	 */
+	public function render_top_active_filters(): void {
+		if ( ! $this->is_shop_archive() ) {
+			return;
+		}
+
+		$chips = $this->get_active_filter_chips();
+		if ( empty( $chips ) ) {
+			return;
+		}
+
+		echo '<div class="wf-top-active-filters">';
+		echo '<div class="wf-chip-list">';
+		foreach ( $chips as $chip ) {
+			echo '<a class="wf-chip" href="' . esc_url( (string) $chip['url'] ) . '">' . esc_html( (string) $chip['label'] ) . ' <span aria-hidden="true">&times;</span></a>';
+		}
+		echo '</div>';
+		echo '<a class="wf-clear-all" href="' . esc_url( $this->build_clear_filters_url() ) . '">' . esc_html__( 'Clear all', 'woo-filters' ) . '</a>';
+		echo '</div>';
+	}
+
+	/**
 	 * Render per-page links.
 	 *
 	 * @return void
@@ -389,6 +415,29 @@ final class ShopFilters {
 	 * @return void
 	 */
 	private function render_active_filters(): void {
+		$chips = $this->get_active_filter_chips();
+
+		if ( empty( $chips ) ) {
+			return;
+		}
+
+		echo '<div class="wf-active-filters">';
+		echo '<h5>' . esc_html__( 'Active Filters', 'woo-filters' ) . '</h5>';
+		echo '<div class="wf-chip-list">';
+		foreach ( $chips as $chip ) {
+			echo '<a class="wf-chip" href="' . esc_url( (string) $chip['url'] ) . '">' . esc_html( (string) $chip['label'] ) . ' <span aria-hidden="true">&times;</span></a>';
+		}
+		echo '</div>';
+		echo '<a class="wf-clear-all" href="' . esc_url( $this->build_clear_filters_url() ) . '">' . esc_html__( 'Clear all', 'woo-filters' ) . '</a>';
+		echo '</div>';
+	}
+
+	/**
+	 * Build a normalized list of active filter chips.
+	 *
+	 * @return array
+	 */
+	private function get_active_filter_chips(): array {
 		$chips = array();
 
 		$selected_category = $this->get_request_slug( 'wf_cat' );
@@ -429,19 +478,7 @@ final class ShopFilters {
 			);
 		}
 
-		if ( empty( $chips ) ) {
-			return;
-		}
-
-		echo '<div class="wf-active-filters">';
-		echo '<h5>' . esc_html__( 'Active Filters', 'woo-filters' ) . '</h5>';
-		echo '<div class="wf-chip-list">';
-		foreach ( $chips as $chip ) {
-			echo '<a class="wf-chip" href="' . esc_url( (string) $chip['url'] ) . '">' . esc_html( (string) $chip['label'] ) . ' <span aria-hidden="true">&times;</span></a>';
-		}
-		echo '</div>';
-		echo '<a class="wf-clear-all" href="' . esc_url( $this->build_clear_filters_url() ) . '">' . esc_html__( 'Clear all', 'woo-filters' ) . '</a>';
-		echo '</div>';
+		return $chips;
 	}
 
 	/**


### PR DESCRIPTION
## Summary
Implements Issue #3 by adding a top active-filter bar above the product loop with removable chips and clear-all support.

## Problem
Active filter state was only visible in the sidebar, which is less discoverable once users focus on product results.

## Scope
- Add top active-filter bar (`.wf-top-active-filters`) above product results
- Reuse the same chip model used by sidebar active filters
- Keep single-chip remove and clear-all interactions
- Ensure AJAX navigation handles top-bar links

## Out of Scope
- Live filter count computation
- Mobile drawer redesign

## Acceptance Criteria Mapping
- Top chips reflect current query state
- Removing a chip updates results and URL state
- Clear-all action resets active filters
- Works in AJAX mode and full-page fallback

## Implementation Notes
- Added `ShopFilters::render_top_active_filters()` on `woocommerce_before_shop_loop`
- Extracted chip construction into `get_active_filter_chips()` to avoid duplicated logic
- Extended JS delegated click selector to include `.wf-top-active-filters`

## Validation
- `php -l src/ShopFilters.php`
- Manual verification of chip links and AJAX interception path

Fixes #3