### PR TITLE
feat: add admin style controls and frontend CSS variable theming

### DIFF
--- a/assets/css/wf-shop.css
+++ b/assets/css/wf-shop.css
@@ -1,13 +1,25 @@
 .wf-shop-layout {
+  --wf-accent: #0b6a78;
+  --wf-sidebar-bg: #ffffff;
+  --wf-sidebar-border: #e5e8ee;
+  --wf-heading-color: #1f2937;
+  --wf-chip-bg: #ffffff;
+  --wf-chip-border: #c7d5e3;
+  --wf-button-bg: #4b5563;
+  --wf-button-text: #ffffff;
+  --wf-font-family: inherit;
+  --wf-font-size: 16px;
   display: grid;
   grid-template-columns: 280px minmax(0, 1fr);
   gap: 24px;
   margin: 24px 0 40px;
+  font-family: var(--wf-font-family);
+  font-size: var(--wf-font-size);
 }
 
 .wf-sidebar {
-  background: #fff;
-  border: 1px solid #e5e8ee;
+  background: var(--wf-sidebar-bg);
+  border: 1px solid var(--wf-sidebar-border);
   border-radius: 10px;
   padding: 18px;
   position: sticky;
@@ -35,12 +47,13 @@
 .wf-filter-block + .wf-filter-block {
   margin-top: 20px;
   padding-top: 16px;
-  border-top: 1px solid #eef1f5;
+  border-top: 1px solid var(--wf-sidebar-border);
 }
 
 .wf-filter-block h4 {
   margin: 0 0 10px;
   font-size: 16px;
+  color: var(--wf-heading-color);
 }
 
 .wf-cat-list,
@@ -66,12 +79,12 @@
 
 .wf-term-list small {
   margin-left: auto;
-  color: #6b7280;
+  color: #5b6472;
 }
 
 .wf-cat-list small {
   margin-left: auto;
-  color: #6b7280;
+  color: #5b6472;
 }
 
 .wf-cat-list label.is-disabled,
@@ -91,7 +104,7 @@
   flex-direction: column;
   gap: 6px;
   font-size: 12px;
-  color: #4b5563;
+  color: #5b6472;
 }
 
 .wf-price-grid input {
@@ -113,6 +126,16 @@
   text-align: center;
 }
 
+.wf-actions .button.alt {
+  background: var(--wf-button-bg);
+  border-color: var(--wf-button-bg);
+  color: var(--wf-button-text);
+}
+
+.wf-actions .button.alt:hover {
+  filter: brightness(0.95);
+}
+
 .wf-products ul.products {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
@@ -130,9 +153,9 @@
 }
 
 .wf-no-results {
-  border: 1px solid #dbe5ee;
+  border: 1px solid var(--wf-sidebar-border);
   border-radius: 10px;
-  background: #f8fbfe;
+  background: var(--wf-sidebar-bg);
   padding: 32px 20px;
   text-align: center;
   margin-top: 12px;
@@ -141,7 +164,7 @@
 .wf-no-results h3 {
   margin: 0 0 8px;
   font-size: 24px;
-  color: #1f2937;
+  color: var(--wf-heading-color);
 }
 
 .wf-no-results p {
@@ -160,17 +183,17 @@
 .wf-active-filters {
   margin-bottom: 16px;
   padding: 10px;
-  border: 1px solid #dbe5ee;
+  border: 1px solid var(--wf-sidebar-border);
   border-radius: 8px;
-  background: #f8fbfe;
+  background: var(--wf-sidebar-bg);
 }
 
 .wf-top-active-filters {
   margin: 0 0 14px;
   padding: 10px;
-  border: 1px solid #dbe5ee;
+  border: 1px solid var(--wf-sidebar-border);
   border-radius: 8px;
-  background: #f8fbfe;
+  background: var(--wf-sidebar-bg);
 }
 
 .wf-active-filters h5 {
@@ -190,19 +213,19 @@
   align-items: center;
   gap: 6px;
   padding: 4px 8px;
-  border: 1px solid #c7d5e3;
+  border: 1px solid var(--wf-chip-border);
   border-radius: 999px;
   font-size: 12px;
-  color: #234;
+  color: #223344;
   text-decoration: none;
-  background: #fff;
+  background: var(--wf-chip-bg);
 }
 
 .wf-clear-all {
   display: inline-block;
   margin-top: 8px;
   font-size: 12px;
-  color: #0b6a78;
+  color: var(--wf-accent);
 }
 
 .wf-products .wf-per-page {
@@ -218,7 +241,7 @@
 }
 
 .wf-products .wf-per-page a.is-active {
-  color: #0b6a78;
+  color: var(--wf-accent);
   font-weight: 600;
 }
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -41,7 +41,7 @@ final class Plugin {
 	 *
 	 * @var string
 	 */
-	private $version = '0.4.0';
+	private $version = '0.5.0';
 
 	/**
 	 * Shop filters service.
@@ -49,6 +49,13 @@ final class Plugin {
 	 * @var ShopFilters|null
 	 */
 	private $shop_filters = null;
+
+	/**
+	 * Style settings service.
+	 *
+	 * @var StyleSettings|null
+	 */
+	private $style_settings = null;
 
 	/**
 	 * Constructor.
@@ -86,5 +93,8 @@ final class Plugin {
 
 		$this->shop_filters = new ShopFilters( $this->plugin_url, $this->version );
 		$this->shop_filters->register_hooks();
+
+		$this->style_settings = new StyleSettings();
+		$this->style_settings->register_hooks();
 	}
 }

--- a/src/ShopFilters.php
+++ b/src/ShopFilters.php
@@ -108,6 +108,7 @@ final class ShopFilters {
 			array(),
 			$this->asset_version
 		);
+		$this->enqueue_inline_styles();
 
 		wp_enqueue_script(
 			'wf-shop-filters',
@@ -124,6 +125,40 @@ final class ShopFilters {
 				'nonce' => $this->get_filter_nonce(),
 			)
 		);
+	}
+
+	/**
+	 * Add user-configured CSS variables and custom CSS.
+	 *
+	 * @return void
+	 */
+	private function enqueue_inline_styles(): void {
+		$options = StyleSettings::get_options();
+
+		$variables = array(
+			'--wf-accent'          => isset( $options['accent_color'] ) ? (string) $options['accent_color'] : '#0b6a78',
+			'--wf-sidebar-bg'      => isset( $options['sidebar_bg_color'] ) ? (string) $options['sidebar_bg_color'] : '#ffffff',
+			'--wf-sidebar-border'  => isset( $options['sidebar_border_color'] ) ? (string) $options['sidebar_border_color'] : '#e5e8ee',
+			'--wf-heading-color'   => isset( $options['heading_color'] ) ? (string) $options['heading_color'] : '#1f2937',
+			'--wf-chip-bg'         => isset( $options['chip_bg_color'] ) ? (string) $options['chip_bg_color'] : '#ffffff',
+			'--wf-chip-border'     => isset( $options['chip_border_color'] ) ? (string) $options['chip_border_color'] : '#c7d5e3',
+			'--wf-button-bg'       => isset( $options['button_bg_color'] ) ? (string) $options['button_bg_color'] : '#4b5563',
+			'--wf-button-text'     => isset( $options['button_text_color'] ) ? (string) $options['button_text_color'] : '#ffffff',
+			'--wf-font-family'     => isset( $options['font_family'] ) ? (string) $options['font_family'] : 'inherit',
+			'--wf-font-size'       => ( isset( $options['font_size'] ) ? absint( $options['font_size'] ) : 16 ) . 'px',
+		);
+
+		$declarations = array();
+		foreach ( $variables as $name => $value ) {
+			$declarations[] = $name . ':' . trim( (string) $value );
+		}
+
+		$css = '.wf-shop-layout{' . implode( ';', $declarations ) . ';}';
+		if ( ! empty( $options['custom_css'] ) ) {
+			$css .= "\n" . (string) $options['custom_css'];
+		}
+
+		wp_add_inline_style( 'wf-shop-filters', $css );
 	}
 
 	/**

--- a/src/StyleSettings.php
+++ b/src/StyleSettings.php
@@ -1,0 +1,290 @@
+<?php
+/**
+ * Style settings controller.
+ *
+ * @package WooFilters
+ */
+
+namespace WooFilters;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Registers and renders admin style options for frontend filter UI.
+ */
+final class StyleSettings {
+	/** @var string */
+	private const OPTION_KEY = 'wf_style_options';
+
+	/** @var string */
+	private const PAGE_SLUG = 'wf-style-settings';
+
+	/**
+	 * Register class hooks.
+	 *
+	 * @return void
+	 */
+	public function register_hooks(): void {
+		add_action( 'admin_init', array( $this, 'register_settings' ) );
+		add_action( 'admin_menu', array( $this, 'register_menu' ) );
+	}
+
+	/**
+	 * Register plugin settings and fields.
+	 *
+	 * @return void
+	 */
+	public function register_settings(): void {
+		register_setting(
+			'wf_style_settings',
+			self::OPTION_KEY,
+			array(
+				'type'              => 'array',
+				'sanitize_callback' => array( $this, 'sanitize_settings' ),
+				'default'           => self::get_defaults(),
+			)
+		);
+
+		add_settings_section(
+			'wf_style_section_main',
+			__( 'Design Controls', 'woo-filters' ),
+			array( $this, 'render_section_intro' ),
+			self::PAGE_SLUG
+		);
+
+		$this->register_color_field( 'accent_color', __( 'Accent Color', 'woo-filters' ) );
+		$this->register_color_field( 'sidebar_bg_color', __( 'Sidebar Background', 'woo-filters' ) );
+		$this->register_color_field( 'sidebar_border_color', __( 'Sidebar Border', 'woo-filters' ) );
+		$this->register_color_field( 'heading_color', __( 'Heading Color', 'woo-filters' ) );
+		$this->register_color_field( 'chip_bg_color', __( 'Filter Chip Background', 'woo-filters' ) );
+		$this->register_color_field( 'chip_border_color', __( 'Filter Chip Border', 'woo-filters' ) );
+		$this->register_color_field( 'button_bg_color', __( 'Primary Button Background', 'woo-filters' ) );
+		$this->register_color_field( 'button_text_color', __( 'Primary Button Text', 'woo-filters' ) );
+		$this->register_text_field( 'font_family', __( 'Font Family', 'woo-filters' ) );
+		$this->register_text_field( 'font_size', __( 'Base Font Size (px)', 'woo-filters' ) );
+
+		add_settings_field(
+			'custom_css',
+			__( 'Custom CSS', 'woo-filters' ),
+			array( $this, 'render_custom_css_field' ),
+			self::PAGE_SLUG,
+			'wf_style_section_main'
+		);
+	}
+
+	/**
+	 * Register submenu under WooCommerce.
+	 *
+	 * @return void
+	 */
+	public function register_menu(): void {
+		add_submenu_page(
+			'woocommerce',
+			__( 'Woo Filters Styling', 'woo-filters' ),
+			__( 'Woo Filters Styling', 'woo-filters' ),
+			'manage_woocommerce',
+			self::PAGE_SLUG,
+			array( $this, 'render_page' )
+		);
+	}
+
+	/**
+	 * Render style settings page.
+	 *
+	 * @return void
+	 */
+	public function render_page(): void {
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			return;
+		}
+
+		echo '<div class="wrap">';
+		echo '<h1>' . esc_html__( 'Woo Filters Styling', 'woo-filters' ) . '</h1>';
+		echo '<form action="options.php" method="post">';
+		settings_fields( 'wf_style_settings' );
+		do_settings_sections( self::PAGE_SLUG );
+		submit_button( __( 'Save Styles', 'woo-filters' ) );
+		echo '</form>';
+		echo '</div>';
+	}
+
+	/**
+	 * Render section copy.
+	 *
+	 * @return void
+	 */
+	public function render_section_intro(): void {
+		echo '<p>' . esc_html__( 'Control frontend filter colors and typography. CSS hooks: .wf-shop-layout, .wf-sidebar, .wf-chip, .wf-actions .button.alt.', 'woo-filters' ) . '</p>';
+	}
+
+	/**
+	 * Register a color picker field.
+	 *
+	 * @param string $key   Field key.
+	 * @param string $label Field label.
+	 * @return void
+	 */
+	private function register_color_field( string $key, string $label ): void {
+		add_settings_field(
+			$key,
+			$label,
+			array( $this, 'render_color_field' ),
+			self::PAGE_SLUG,
+			'wf_style_section_main',
+			array(
+				'key' => $key,
+			)
+		);
+	}
+
+	/**
+	 * Register a text input field.
+	 *
+	 * @param string $key   Field key.
+	 * @param string $label Field label.
+	 * @return void
+	 */
+	private function register_text_field( string $key, string $label ): void {
+		add_settings_field(
+			$key,
+			$label,
+			array( $this, 'render_text_field' ),
+			self::PAGE_SLUG,
+			'wf_style_section_main',
+			array(
+				'key' => $key,
+			)
+		);
+	}
+
+	/**
+	 * Render color input.
+	 *
+	 * @param array $args Field args.
+	 * @return void
+	 */
+	public function render_color_field( array $args ): void {
+		$key     = isset( $args['key'] ) ? sanitize_key( (string) $args['key'] ) : '';
+		$options = self::get_options();
+		$value   = isset( $options[ $key ] ) ? (string) $options[ $key ] : '';
+
+		echo '<input type="color" name="' . esc_attr( self::OPTION_KEY ) . '[' . esc_attr( $key ) . ']" value="' . esc_attr( $value ) . '" />';
+	}
+
+	/**
+	 * Render text input.
+	 *
+	 * @param array $args Field args.
+	 * @return void
+	 */
+	public function render_text_field( array $args ): void {
+		$key     = isset( $args['key'] ) ? sanitize_key( (string) $args['key'] ) : '';
+		$options = self::get_options();
+		$value   = isset( $options[ $key ] ) ? (string) $options[ $key ] : '';
+
+		echo '<input type="text" class="regular-text" name="' . esc_attr( self::OPTION_KEY ) . '[' . esc_attr( $key ) . ']" value="' . esc_attr( $value ) . '" />';
+	}
+
+	/**
+	 * Render custom CSS textarea.
+	 *
+	 * @return void
+	 */
+	public function render_custom_css_field(): void {
+		$options = self::get_options();
+		$value   = isset( $options['custom_css'] ) ? (string) $options['custom_css'] : '';
+
+		echo '<textarea name="' . esc_attr( self::OPTION_KEY ) . '[custom_css]" rows="8" class="large-text code">' . esc_textarea( $value ) . '</textarea>';
+	}
+
+	/**
+	 * Sanitize settings payload.
+	 *
+	 * @param mixed $raw Raw settings data.
+	 * @return array
+	 */
+	public function sanitize_settings( $raw ): array {
+		$defaults = self::get_defaults();
+		if ( ! is_array( $raw ) ) {
+			return $defaults;
+		}
+
+		$sanitized = $defaults;
+		$colors    = array(
+			'accent_color',
+			'sidebar_bg_color',
+			'sidebar_border_color',
+			'heading_color',
+			'chip_bg_color',
+			'chip_border_color',
+			'button_bg_color',
+			'button_text_color',
+		);
+
+		foreach ( $colors as $key ) {
+			$input = isset( $raw[ $key ] ) ? sanitize_text_field( wp_unslash( (string) $raw[ $key ] ) ) : '';
+			$color = sanitize_hex_color( $input );
+
+			if ( null !== $color && '' !== $color ) {
+				$sanitized[ $key ] = $color;
+			}
+		}
+
+		$font_family = isset( $raw['font_family'] ) ? sanitize_text_field( wp_unslash( (string) $raw['font_family'] ) ) : '';
+		if ( '' !== $font_family ) {
+			$safe_font = preg_replace( '/[^a-zA-Z0-9,\-\'\"\s]/', '', $font_family );
+			if ( is_string( $safe_font ) && '' !== $safe_font ) {
+				$sanitized['font_family'] = $safe_font;
+			}
+		}
+
+		$font_size = isset( $raw['font_size'] ) ? absint( wp_unslash( (string) $raw['font_size'] ) ) : 0;
+		if ( $font_size >= 12 && $font_size <= 24 ) {
+			$sanitized['font_size'] = (string) $font_size;
+		}
+
+		$custom_css = isset( $raw['custom_css'] ) ? sanitize_textarea_field( wp_unslash( (string) $raw['custom_css'] ) ) : '';
+		if ( '' !== $custom_css ) {
+			$sanitized['custom_css'] = $custom_css;
+		}
+
+		return $sanitized;
+	}
+
+	/**
+	 * Get merged options with defaults.
+	 *
+	 * @return array
+	 */
+	public static function get_options(): array {
+		$options = get_option( self::OPTION_KEY, array() );
+		if ( ! is_array( $options ) ) {
+			$options = array();
+		}
+
+		return array_merge( self::get_defaults(), $options );
+	}
+
+	/**
+	 * Get default style values.
+	 *
+	 * @return array
+	 */
+	private static function get_defaults(): array {
+		return array(
+			'accent_color'        => '#0b6a78',
+			'sidebar_bg_color'    => '#ffffff',
+			'sidebar_border_color' => '#e5e8ee',
+			'heading_color'       => '#1f2937',
+			'chip_bg_color'       => '#ffffff',
+			'chip_border_color'   => '#c7d5e3',
+			'button_bg_color'     => '#4b5563',
+			'button_text_color'   => '#ffffff',
+			'font_family'         => 'inherit',
+			'font_size'           => '16',
+			'custom_css'          => '',
+		);
+	}
+}

--- a/woo-filters.php
+++ b/woo-filters.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Woo Filters
  * Description: Shop/archive filters for WooCommerce.
- * Version: 0.4.0
+ * Version: 0.5.0
  * Author: Anisur Rahman
  * Author URI: https://github.com/anisur2805
  * Requires at least: 6.0


### PR DESCRIPTION
## Summary
- add a new WooCommerce submenu page: Woo Filters Styling
- register style settings via Settings API with sanitization for color, typography, and custom CSS fields
- introduce CSS-variable driven theming for filter UI components (sidebar, headings, chips, action button, accent links)
- inject inline CSS variables and optional custom CSS on shop/shortcode contexts
- bump plugin version to 0.5.0 for cache-safe asset updates

## Technical Details
- new class: `WooFilters\\StyleSettings` (PSR-4, OOP service)
- plugin bootstrap now initializes both `ShopFilters` and `StyleSettings`
- frontend uses scoped variables on `.wf-shop-layout` to avoid global style side effects
- sanitization hardening includes hex color validation, bounded font size, and filtered font-family input

## Validation
- php syntax checks:
  - `php -l src/StyleSettings.php`
  - `php -l src/Plugin.php`
  - `php -l src/ShopFilters.php`
  - `php -l woo-filters.php`
- manual diff review for settings flow, option output safety, and CSS scope consistency

## Notes
- PHPCS/WPCS command was not available in this environment (`vendor/bin/phpcs` missing), so static sniffs were validated by code review + strict sanitization patterns.

Closes #16