### PR TITLE
feat: add draggable price slider with min/max sync

### DIFF
--- a/assets/css/wf-shop.css
+++ b/assets/css/wf-shop.css
@@ -97,6 +97,78 @@
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 10px;
+  margin-top: 14px;
+}
+
+.wf-price-slider {
+  position: relative;
+}
+
+.wf-price-range-inputs {
+  position: relative;
+  height: 24px;
+}
+
+.wf-price-range {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  margin: 0;
+  background: transparent;
+  pointer-events: none;
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+.wf-price-range::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 2px solid var(--wf-accent);
+  background: #fff;
+  pointer-events: auto;
+  cursor: pointer;
+}
+
+.wf-price-range::-webkit-slider-runnable-track {
+  height: 4px;
+  background: transparent;
+}
+
+.wf-price-range::-moz-range-thumb {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 2px solid var(--wf-accent);
+  background: #fff;
+  pointer-events: auto;
+  cursor: pointer;
+}
+
+.wf-price-range::-moz-range-track {
+  height: 4px;
+  background: transparent;
+}
+
+.wf-price-track {
+  position: relative;
+  height: 4px;
+  border-radius: 999px;
+  background: #d8dee8;
+  margin-top: -12px;
+}
+
+.wf-price-track-fill {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  border-radius: 999px;
+  background: var(--wf-accent);
 }
 
 .wf-price-grid label {

--- a/assets/css/wf-shop.css
+++ b/assets/css/wf-shop.css
@@ -120,8 +120,9 @@
 
 .wf-price-slider {
   position: relative;
-  height: 26px;
+  height: 28px;
   margin-top: 6px;
+  padding: 0 8px;
 }
 
 .wf-price-range-inputs {
@@ -131,9 +132,9 @@
 
 .wf-price-range {
   position: absolute;
-  left: 0;
+  left: 8px;
   top: 0;
-  width: 100%;
+  width: calc(100% - 16px);
   height: 26px;
   margin: 0;
   background: transparent;
@@ -152,6 +153,7 @@
   background: #fff;
   pointer-events: auto;
   cursor: pointer;
+  box-shadow: 0 0 0 2px #fff;
 }
 
 .wf-price-range::-webkit-slider-runnable-track {
@@ -167,6 +169,7 @@
   background: #fff;
   pointer-events: auto;
   cursor: pointer;
+  box-shadow: 0 0 0 2px #fff;
 }
 
 .wf-price-range::-moz-range-track {
@@ -176,8 +179,8 @@
 
 .wf-price-track {
   position: absolute;
-  left: 0;
-  right: 0;
+  left: 8px;
+  right: 8px;
   top: 11px;
   height: 4px;
   border-radius: 999px;
@@ -218,7 +221,16 @@
 
 .wf-actions .button {
   flex: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   text-align: center;
+  min-height: 44px;
+  padding: 0 14px;
+  font-size: 16px;
+  line-height: 1.2;
+  white-space: nowrap;
+  border-radius: 6px;
 }
 
 .wf-actions .button.alt {

--- a/assets/css/wf-shop.css
+++ b/assets/css/wf-shop.css
@@ -63,6 +63,24 @@
   padding: 0;
 }
 
+.wf-sidebar .wf-cat-list,
+.wf-sidebar .wf-term-list {
+  list-style: none !important;
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+.wf-sidebar .wf-cat-list li::before,
+.wf-sidebar .wf-term-list li::before {
+  content: none !important;
+  display: none !important;
+}
+
+.wf-sidebar .wf-cat-list li::marker,
+.wf-sidebar .wf-term-list li::marker {
+  content: '' !important;
+}
+
 .wf-cat-list li,
 .wf-term-list li {
   margin: 8px 0;
@@ -102,11 +120,13 @@
 
 .wf-price-slider {
   position: relative;
+  height: 26px;
+  margin-top: 6px;
 }
 
 .wf-price-range-inputs {
-  position: relative;
-  height: 24px;
+  position: absolute;
+  inset: 0;
 }
 
 .wf-price-range {
@@ -114,6 +134,7 @@
   left: 0;
   top: 0;
   width: 100%;
+  height: 26px;
   margin: 0;
   background: transparent;
   pointer-events: none;
@@ -154,11 +175,13 @@
 }
 
 .wf-price-track {
-  position: relative;
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 11px;
   height: 4px;
   border-radius: 999px;
   background: #d8dee8;
-  margin-top: -12px;
 }
 
 .wf-price-track-fill {

--- a/assets/js/wf-shop.js
+++ b/assets/js/wf-shop.js
@@ -108,6 +108,125 @@
     if (incomingProducts && currentProducts) {
       currentProducts.replaceWith(incomingProducts);
     }
+
+    initPriceSliders();
+  }
+
+  function parseFloatSafe(value, fallback) {
+    var numeric = Number.parseFloat(value);
+    return Number.isFinite(numeric) ? numeric : fallback;
+  }
+
+  function clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
+  }
+
+  function formatDecimal(value) {
+    return String(Number(value.toFixed(2)));
+  }
+
+  function dispatchInputEvent(target) {
+    target.dispatchEvent(new Event('input', { bubbles: true }));
+  }
+
+  function initPriceSliders() {
+    var forms = layout.querySelectorAll('.wf-filter-form');
+    forms.forEach(function (form) {
+      var slider = form.querySelector('.wf-price-slider');
+      var minInput = form.querySelector('input[name="min_price"]');
+      var maxInput = form.querySelector('input[name="max_price"]');
+
+      if (!slider || !minInput || !maxInput) {
+        return;
+      }
+
+      var rangeMin = slider.querySelector('.wf-price-range-min');
+      var rangeMax = slider.querySelector('.wf-price-range-max');
+      var trackFill = slider.querySelector('.wf-price-track-fill');
+
+      if (!rangeMin || !rangeMax || !trackFill) {
+        return;
+      }
+
+      var sliderMin = parseFloatSafe(slider.dataset.min, 0);
+      var sliderMax = parseFloatSafe(slider.dataset.max, sliderMin + 100);
+      if (sliderMax <= sliderMin) {
+        sliderMax = sliderMin + 100;
+      }
+
+      function updateTrack(minValue, maxValue) {
+        var range = sliderMax - sliderMin;
+        if (range <= 0) {
+          trackFill.style.left = '0%';
+          trackFill.style.width = '100%';
+          return;
+        }
+
+        var minPercent = ((minValue - sliderMin) / range) * 100;
+        var maxPercent = ((maxValue - sliderMin) / range) * 100;
+        trackFill.style.left = minPercent + '%';
+        trackFill.style.width = Math.max(0, maxPercent - minPercent) + '%';
+      }
+
+      function syncFromNumberInputs(source) {
+        var minValue = parseFloatSafe(minInput.value, sliderMin);
+        var maxValue = parseFloatSafe(maxInput.value, sliderMax);
+
+        minValue = clamp(minValue, sliderMin, sliderMax);
+        maxValue = clamp(maxValue, sliderMin, sliderMax);
+
+        if (minValue > maxValue) {
+          if (source === 'min') {
+            maxValue = minValue;
+          } else {
+            minValue = maxValue;
+          }
+        }
+
+        rangeMin.value = formatDecimal(minValue);
+        rangeMax.value = formatDecimal(maxValue);
+        updateTrack(minValue, maxValue);
+      }
+
+      function syncFromRangeInputs(source) {
+        var minValue = parseFloatSafe(rangeMin.value, sliderMin);
+        var maxValue = parseFloatSafe(rangeMax.value, sliderMax);
+
+        if (minValue > maxValue) {
+          if (source === 'min') {
+            maxValue = minValue;
+            rangeMax.value = formatDecimal(maxValue);
+          } else {
+            minValue = maxValue;
+            rangeMin.value = formatDecimal(minValue);
+          }
+        }
+
+        minInput.value = formatDecimal(minValue);
+        maxInput.value = formatDecimal(maxValue);
+        updateTrack(minValue, maxValue);
+
+        dispatchInputEvent(minInput);
+      }
+
+      rangeMin.addEventListener('input', function () {
+        syncFromRangeInputs('min');
+      });
+
+      rangeMax.addEventListener('input', function () {
+        syncFromRangeInputs('max');
+      });
+
+      minInput.addEventListener('input', function () {
+        syncFromNumberInputs('min');
+      });
+
+      maxInput.addEventListener('input', function () {
+        syncFromNumberInputs('max');
+      });
+
+      syncFromNumberInputs('');
+    });
   }
 
   function requestAndSwap(url, options) {
@@ -248,4 +367,6 @@
   window.addEventListener('popstate', function () {
     requestAndSwap(window.location.href, { pushState: false });
   });
+
+  initPriceSliders();
 })();

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -41,7 +41,7 @@ final class Plugin {
 	 *
 	 * @var string
 	 */
-	private $version = '0.5.0';
+	private $version = '0.6.0';
 
 	/**
 	 * Shop filters service.

--- a/src/ShopFilters.php
+++ b/src/ShopFilters.php
@@ -421,6 +421,17 @@ final class ShopFilters {
 		$max_price       = $this->get_request_decimal( 'max_price' );
 		$in_stock_only   = $this->get_request_flag( 'wf_in_stock' );
 		$on_sale_only    = $this->get_request_flag( 'wf_on_sale' );
+		$price_bounds    = $this->get_price_bounds();
+		$slider_min      = $price_bounds['min'];
+		$slider_max      = $price_bounds['max'];
+		$current_min     = null !== $min_price ? $min_price : $slider_min;
+		$current_max     = null !== $max_price ? $max_price : $slider_max;
+
+		if ( $current_min > $current_max ) {
+			$tmp         = $current_min;
+			$current_min = $current_max;
+			$current_max = $tmp;
+		}
 
 		echo '<form class="wf-filter-form" method="get" action="' . esc_url( $action ) . '">';
 		echo '<input type="hidden" name="wf_nonce" value="' . esc_attr( $this->get_filter_nonce() ) . '" />';
@@ -441,9 +452,16 @@ final class ShopFilters {
 
 		echo '<div class="wf-filter-block">';
 		echo '<h4>' . esc_html__( 'Price', 'woo-filters' ) . '</h4>';
+		echo '<div class="wf-price-slider" data-min="' . esc_attr( $this->format_decimal_for_input( $slider_min ) ) . '" data-max="' . esc_attr( $this->format_decimal_for_input( $slider_max ) ) . '" data-step="0.01">';
+		echo '<div class="wf-price-range-inputs">';
+		echo '<input class="wf-price-range wf-price-range-min" type="range" aria-label="' . esc_attr__( 'Minimum price', 'woo-filters' ) . '" min="' . esc_attr( $this->format_decimal_for_input( $slider_min ) ) . '" max="' . esc_attr( $this->format_decimal_for_input( $slider_max ) ) . '" step="0.01" value="' . esc_attr( $this->format_decimal_for_input( $current_min ) ) . '" />';
+		echo '<input class="wf-price-range wf-price-range-max" type="range" aria-label="' . esc_attr__( 'Maximum price', 'woo-filters' ) . '" min="' . esc_attr( $this->format_decimal_for_input( $slider_min ) ) . '" max="' . esc_attr( $this->format_decimal_for_input( $slider_max ) ) . '" step="0.01" value="' . esc_attr( $this->format_decimal_for_input( $current_max ) ) . '" />';
+		echo '</div>';
+		echo '<div class="wf-price-track"><span class="wf-price-track-fill"></span></div>';
+		echo '</div>';
 		echo '<div class="wf-price-grid">';
-		echo '<label><span>' . esc_html__( 'Min', 'woo-filters' ) . '</span><input type="number" min="0" step="0.01" name="min_price" value="' . esc_attr( $this->format_decimal_for_input( $min_price ) ) . '" /></label>';
-		echo '<label><span>' . esc_html__( 'Max', 'woo-filters' ) . '</span><input type="number" min="0" step="0.01" name="max_price" value="' . esc_attr( $this->format_decimal_for_input( $max_price ) ) . '" /></label>';
+		echo '<label><span>' . esc_html__( 'Min', 'woo-filters' ) . '</span><input type="number" min="' . esc_attr( $this->format_decimal_for_input( $slider_min ) ) . '" max="' . esc_attr( $this->format_decimal_for_input( $slider_max ) ) . '" step="0.01" name="min_price" value="' . esc_attr( $this->format_decimal_for_input( $min_price ) ) . '" placeholder="' . esc_attr( $this->format_decimal_for_input( $slider_min ) ) . '" /></label>';
+		echo '<label><span>' . esc_html__( 'Max', 'woo-filters' ) . '</span><input type="number" min="' . esc_attr( $this->format_decimal_for_input( $slider_min ) ) . '" max="' . esc_attr( $this->format_decimal_for_input( $slider_max ) ) . '" step="0.01" name="max_price" value="' . esc_attr( $this->format_decimal_for_input( $max_price ) ) . '" placeholder="' . esc_attr( $this->format_decimal_for_input( $slider_max ) ) . '" /></label>';
 		echo '</div>';
 		echo '</div>';
 
@@ -1431,6 +1449,62 @@ final class ShopFilters {
 	}
 
 	/**
+	 * Get global product price boundaries for slider controls.
+	 *
+	 * @return array{min: float, max: float}
+	 */
+	private function get_price_bounds(): array {
+		$cache_key = 'price_bounds';
+		$cached    = wp_cache_get( $cache_key, self::CACHE_GROUP );
+
+		if ( is_array( $cached ) && isset( $cached['min'], $cached['max'] ) ) {
+			return array(
+				'min' => (float) $cached['min'],
+				'max' => (float) $cached['max'],
+			);
+		}
+
+		global $wpdb;
+
+		$sql = $wpdb->prepare(
+			"SELECT
+				MIN(CAST(pm.meta_value AS DECIMAL(20, 4))) AS min_price,
+				MAX(CAST(pm.meta_value AS DECIMAL(20, 4))) AS max_price
+			FROM {$wpdb->posts} AS p
+			INNER JOIN {$wpdb->postmeta} AS pm ON p.ID = pm.post_id
+			WHERE pm.meta_key = %s
+				AND pm.meta_value <> ''
+				AND p.post_type = %s
+				AND p.post_status = %s",
+			'_price',
+			'product',
+			'publish'
+		);
+
+		$row = $wpdb->get_row( $sql, ARRAY_A );
+
+		$min = isset( $row['min_price'] ) ? (float) $row['min_price'] : 0.0;
+		$max = isset( $row['max_price'] ) ? (float) $row['max_price'] : 0.0;
+
+		if ( $min < 0 ) {
+			$min = 0.0;
+		}
+
+		if ( $max <= $min ) {
+			$max = $min + 100;
+		}
+
+		$bounds = array(
+			'min' => $min,
+			'max' => $max,
+		);
+
+		wp_cache_set( $cache_key, $bounds, self::CACHE_GROUP, 300 );
+
+		return $bounds;
+	}
+
+	/**
 	 * Format decimal value for numeric input fields.
 	 *
 	 * @param float|null $value Decimal value.
@@ -1441,6 +1515,8 @@ final class ShopFilters {
 			return '';
 		}
 
-		return rtrim( rtrim( (string) $value, '0' ), '.' );
+		$formatted = rtrim( rtrim( sprintf( '%.4F', $value ), '0' ), '.' );
+
+		return '' !== $formatted ? $formatted : '0';
 	}
 }

--- a/woo-filters.php
+++ b/woo-filters.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Woo Filters
  * Description: Shop/archive filters for WooCommerce.
- * Version: 0.5.0
+ * Version: 0.6.0
  * Author: Anisur Rahman
  * Author URI: https://github.com/anisur2805
  * Requires at least: 6.0


### PR DESCRIPTION
## Summary
- add dual-handle draggable price slider to the filter sidebar
- keep slider values synchronized with existing min/max number inputs
- preserve existing AJAX behavior by dispatching debounced input updates from slider interactions
- compute slider bounds dynamically from published product prices with short-lived object-cache storage
- harden numeric formatting so zero values render correctly in inputs
- bump plugin version to 0.6.0

## Technical Notes
- new backend helper in ShopFilters: global price bounds resolver with caching
- slider UI is progressive: existing numeric fields remain functional and now act as synchronized controls
- synchronization supports both directions:
  - drag slider -> update min/max inputs
  - edit min/max inputs -> update slider thumbs + selected track
- added accessibility labels for slider handles

## Validation
- php syntax checks passed:
  - `php -l src/ShopFilters.php`
  - `php -l src/Plugin.php`
  - `php -l woo-filters.php`
- manual review completed for AJAX request flow and query arg compatibility

## Scope
- does not alter current query semantics; still uses existing `min_price` / `max_price` filtering backend

Closes #17