### PR TITLE
feat: add live search inside taxonomy filter option lists

### DIFF
--- a/assets/css/wf-shop.css
+++ b/assets/css/wf-shop.css
@@ -111,6 +111,24 @@
   cursor: not-allowed;
 }
 
+.wf-option-search-wrap {
+  margin-bottom: 10px;
+}
+
+.wf-option-search {
+  width: 100%;
+  min-height: 36px;
+  padding: 7px 10px;
+  border: 1px solid var(--wf-sidebar-border);
+  border-radius: 6px;
+  background: #fff;
+  font-size: 13px;
+}
+
+.wf-option-hidden {
+  display: none !important;
+}
+
 .wf-price-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;

--- a/assets/js/wf-shop.js
+++ b/assets/js/wf-shop.js
@@ -110,6 +110,34 @@
     }
 
     initPriceSliders();
+    initOptionSearch();
+  }
+
+  function initOptionSearch() {
+    var searchInputs = layout.querySelectorAll('.wf-option-search');
+    searchInputs.forEach(function (input) {
+      var listId = input.getAttribute('data-list-id') || '';
+      var list = listId ? document.getElementById(listId) : null;
+      if (!list) {
+        return;
+      }
+
+      function filterItems() {
+        var query = String(input.value || '')
+          .trim()
+          .toLowerCase();
+        var items = list.querySelectorAll('li');
+
+        items.forEach(function (item) {
+          var label = item.querySelector('label span');
+          var text = label ? String(label.textContent || '').trim().toLowerCase() : '';
+          item.classList.toggle('wf-option-hidden', query !== '' && text.indexOf(query) === -1);
+        });
+      }
+
+      input.addEventListener('input', filterItems);
+      filterItems();
+    });
   }
 
   function parseFloatSafe(value, fallback) {
@@ -312,6 +340,10 @@
 
     var filterForm = target.form;
     if (filterForm && filterForm.classList.contains('wf-filter-form')) {
+      if (target.classList.contains('wf-option-search')) {
+        return;
+      }
+
       if (target.name === 'min_price' || target.name === 'max_price') {
         return;
       }
@@ -369,4 +401,5 @@
   });
 
   initPriceSliders();
+  initOptionSearch();
 })();

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -41,7 +41,7 @@ final class Plugin {
 	 *
 	 * @var string
 	 */
-	private $version = '0.6.0';
+	private $version = '0.7.0';
 
 	/**
 	 * Shop filters service.

--- a/src/ShopFilters.php
+++ b/src/ShopFilters.php
@@ -644,7 +644,15 @@ final class ShopFilters {
 			return;
 		}
 
-		echo '<ul class="wf-term-list">';
+		$list_id = 'wf-term-list-' . sanitize_key( $taxonomy );
+
+		if ( count( $terms ) > 7 ) {
+			echo '<div class="wf-option-search-wrap">';
+			echo '<input type="search" class="wf-option-search" data-list-id="' . esc_attr( $list_id ) . '" placeholder="' . esc_attr__( 'Search options...', 'woo-filters' ) . '" aria-label="' . esc_attr__( 'Search filter options', 'woo-filters' ) . '" />';
+			echo '</div>';
+		}
+
+		echo '<ul id="' . esc_attr( $list_id ) . '" class="wf-term-list">';
 		foreach ( $terms as $term ) {
 			$live_count = $this->get_contextual_term_count( $taxonomy, $term->slug, $request_key );
 			$checked    = in_array( $term->slug, $selected_values, true );

--- a/woo-filters.php
+++ b/woo-filters.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Woo Filters
  * Description: Shop/archive filters for WooCommerce.
- * Version: 0.6.0
+ * Version: 0.7.0
  * Author: Anisur Rahman
  * Author URI: https://github.com/anisur2805
  * Requires at least: 6.0


### PR DESCRIPTION
## Summary
- add in-filter live search input for long taxonomy option lists (brands/colors)
- filter option items client-side as user types, without page refresh
- exclude search input interactions from AJAX filter submission triggers
- preserve compatibility with existing AJAX swap cycle by re-initializing search handlers after DOM replacement
- bump plugin version to 0.7.0 for reliable asset cache busting

## Implementation Details
- `ShopFilters::render_term_checkboxes()` now renders a search input when a taxonomy list has more than 7 options
- each searchable list gets a deterministic id and the search input links via `data-list-id`
- JS adds `initOptionSearch()` to handle option filtering and rebind after AJAX swaps
- CSS introduces scoped styles for search field and hidden-result rows

## Validation
- php syntax checks passed:
  - `php -l src/ShopFilters.php`
  - `php -l src/Plugin.php`
  - `php -l woo-filters.php`
- manual review completed for AJAX-change guards and live DOM replacement behavior

Closes #18