### PR TITLE
feat: add 3 default UI skin presets with admin selector

### DIFF
--- a/assets/css/wf-shop.css
+++ b/assets/css/wf-shop.css
@@ -370,6 +370,30 @@
   font-weight: 600;
 }
 
+.wf-shop-layout.wf-skin-graphite .wf-sidebar {
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
+}
+
+.wf-shop-layout.wf-skin-graphite .wf-chip {
+  border-radius: 6px;
+}
+
+.wf-shop-layout.wf-skin-sunrise .wf-sidebar {
+  box-shadow: 0 12px 28px rgba(234, 88, 12, 0.12);
+}
+
+.wf-shop-layout.wf-skin-sunrise .wf-filter-block h4 {
+  letter-spacing: 0.2px;
+}
+
+.wf-shop-layout.wf-skin-sunrise .wf-chip {
+  border-radius: 14px;
+}
+
+.wf-shop-layout.wf-skin-sunrise .wf-actions .button.alt {
+  box-shadow: 0 8px 18px rgba(234, 88, 12, 0.26);
+}
+
 @media (max-width: 1024px) {
   .wf-shop-layout {
     grid-template-columns: 240px minmax(0, 1fr);

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -41,7 +41,7 @@ final class Plugin {
 	 *
 	 * @var string
 	 */
-	private $version = '0.7.0';
+	private $version = '0.8.0';
 
 	/**
 	 * Shop filters service.

--- a/src/ShopFilters.php
+++ b/src/ShopFilters.php
@@ -261,9 +261,10 @@ final class ShopFilters {
 
 		$this->is_shortcode_context = true;
 		$this->shortcode_action_url = get_permalink();
+		$skin_class                 = $this->get_layout_skin_class();
 
 		ob_start();
-		echo '<div class="wf-shop-layout wf-shortcode-layout">';
+		echo '<div class="wf-shop-layout wf-shortcode-layout ' . esc_attr( $skin_class ) . '">';
 		echo '<aside class="wf-sidebar">';
 		$this->render_filter_form();
 		echo '</aside>';
@@ -301,7 +302,7 @@ final class ShopFilters {
 			return;
 		}
 
-		echo '<div class="wf-shop-layout">';
+		echo '<div class="wf-shop-layout ' . esc_attr( $this->get_layout_skin_class() ) . '">';
 		echo '<aside class="wf-sidebar">';
 		$this->render_filter_form();
 		echo '</aside>';
@@ -1454,6 +1455,18 @@ final class ShopFilters {
 	 */
 	private function is_query_shop_archive( \WP_Query $query ): bool {
 		return (bool) ( $query->is_post_type_archive( 'product' ) || $query->is_tax( get_object_taxonomies( 'product' ) ) );
+	}
+
+	/**
+	 * Get CSS class name for active style preset.
+	 *
+	 * @return string
+	 */
+	private function get_layout_skin_class(): string {
+		$options = StyleSettings::get_options();
+		$skin    = isset( $options['preset_skin'] ) ? sanitize_key( (string) $options['preset_skin'] ) : 'classic';
+
+		return 'wf-skin-' . $skin;
 	}
 
 	/**

--- a/src/StyleSettings.php
+++ b/src/StyleSettings.php
@@ -54,6 +54,14 @@ final class StyleSettings {
 			self::PAGE_SLUG
 		);
 
+		add_settings_field(
+			'preset_skin',
+			__( 'Default Skin', 'woo-filters' ),
+			array( $this, 'render_skin_field' ),
+			self::PAGE_SLUG,
+			'wf_style_section_main'
+		);
+
 		$this->register_color_field( 'accent_color', __( 'Accent Color', 'woo-filters' ) );
 		$this->register_color_field( 'sidebar_bg_color', __( 'Sidebar Background', 'woo-filters' ) );
 		$this->register_color_field( 'sidebar_border_color', __( 'Sidebar Border', 'woo-filters' ) );
@@ -116,7 +124,23 @@ final class StyleSettings {
 	 * @return void
 	 */
 	public function render_section_intro(): void {
-		echo '<p>' . esc_html__( 'Control frontend filter colors and typography. CSS hooks: .wf-shop-layout, .wf-sidebar, .wf-chip, .wf-actions .button.alt.', 'woo-filters' ) . '</p>';
+		echo '<p>' . esc_html__( 'Choose a preset skin and fine-tune colors/typography. CSS hooks: .wf-shop-layout, .wf-sidebar, .wf-chip, .wf-actions .button.alt.', 'woo-filters' ) . '</p>';
+	}
+
+	/**
+	 * Render skin select field.
+	 *
+	 * @return void
+	 */
+	public function render_skin_field(): void {
+		$options      = self::get_options();
+		$current_skin = isset( $options['preset_skin'] ) ? self::sanitize_skin( (string) $options['preset_skin'] ) : 'classic';
+
+		echo '<select name="' . esc_attr( self::OPTION_KEY ) . '[preset_skin]">';
+		foreach ( self::get_skin_choices() as $slug => $label ) {
+			echo '<option value="' . esc_attr( $slug ) . '" ' . selected( $current_skin, $slug, false ) . '>' . esc_html( $label ) . '</option>';
+		}
+		echo '</select>';
 	}
 
 	/**
@@ -206,12 +230,12 @@ final class StyleSettings {
 	 * @return array
 	 */
 	public function sanitize_settings( $raw ): array {
-		$defaults = self::get_defaults();
 		if ( ! is_array( $raw ) ) {
-			return $defaults;
+			return self::get_defaults();
 		}
 
-		$sanitized = $defaults;
+		$sanitized                = array();
+		$sanitized['preset_skin'] = self::sanitize_skin( isset( $raw['preset_skin'] ) ? (string) $raw['preset_skin'] : 'classic' );
 		$colors    = array(
 			'accent_color',
 			'sidebar_bg_color',
@@ -264,7 +288,14 @@ final class StyleSettings {
 			$options = array();
 		}
 
-		return array_merge( self::get_defaults(), $options );
+		$defaults = self::get_defaults();
+		$skin     = isset( $options['preset_skin'] ) ? self::sanitize_skin( (string) $options['preset_skin'] ) : 'classic';
+		$preset   = self::get_skin_values( $skin );
+		$merged   = array_merge( $defaults, $preset, $options );
+
+		$merged['preset_skin'] = $skin;
+
+		return $merged;
 	}
 
 	/**
@@ -274,6 +305,7 @@ final class StyleSettings {
 	 */
 	private static function get_defaults(): array {
 		return array(
+			'preset_skin'          => 'classic',
 			'accent_color'        => '#0b6a78',
 			'sidebar_bg_color'    => '#ffffff',
 			'sidebar_border_color' => '#e5e8ee',
@@ -286,5 +318,66 @@ final class StyleSettings {
 			'font_size'           => '16',
 			'custom_css'          => '',
 		);
+	}
+
+	/**
+	 * Get available preset skins.
+	 *
+	 * @return array<string, string>
+	 */
+	private static function get_skin_choices(): array {
+		return array(
+			'classic'  => __( 'Classic', 'woo-filters' ),
+			'graphite' => __( 'Graphite', 'woo-filters' ),
+			'sunrise'  => __( 'Sunrise', 'woo-filters' ),
+		);
+	}
+
+	/**
+	 * Sanitize skin value.
+	 *
+	 * @param string $skin Raw skin.
+	 * @return string
+	 */
+	private static function sanitize_skin( string $skin ): string {
+		$skin = sanitize_key( $skin );
+
+		return array_key_exists( $skin, self::get_skin_choices() ) ? $skin : 'classic';
+	}
+
+	/**
+	 * Get style variables for a preset skin.
+	 *
+	 * @param string $skin Skin key.
+	 * @return array
+	 */
+	private static function get_skin_values( string $skin ): array {
+		switch ( self::sanitize_skin( $skin ) ) {
+			case 'graphite':
+				return array(
+					'accent_color'         => '#0f766e',
+					'sidebar_bg_color'     => '#f8fafc',
+					'sidebar_border_color' => '#d1d5db',
+					'heading_color'        => '#111827',
+					'chip_bg_color'        => '#f9fafb',
+					'chip_border_color'    => '#94a3b8',
+					'button_bg_color'      => '#334155',
+					'button_text_color'    => '#f8fafc',
+				);
+			case 'sunrise':
+				return array(
+					'accent_color'         => '#c2410c',
+					'sidebar_bg_color'     => '#fffaf5',
+					'sidebar_border_color' => '#fed7aa',
+					'heading_color'        => '#7c2d12',
+					'chip_bg_color'        => '#fff7ed',
+					'chip_border_color'    => '#fdba74',
+					'button_bg_color'      => '#ea580c',
+					'button_text_color'    => '#ffffff',
+				);
+			case 'classic':
+			default:
+				return array();
+		}
 	}
 }

--- a/woo-filters.php
+++ b/woo-filters.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Woo Filters
  * Description: Shop/archive filters for WooCommerce.
- * Version: 0.7.0
+ * Version: 0.8.0
  * Author: Anisur Rahman
  * Author URI: https://github.com/anisur2805
  * Requires at least: 6.0


### PR DESCRIPTION
## Summary
- add `Default Skin` control in Woo Filters Styling settings
- introduce three preset skins: Classic, Graphite, Sunrise
- apply preset palettes to filter UI variables (accent, sidebar, chips, buttons, headings)
- attach active skin class to shop/shortcode layout wrappers for extra stylistic polish
- allow custom style fields to continue overriding preset values where provided
- bump plugin version to 0.8.0 for reliable stylesheet cache invalidation

## Technical Details
- `StyleSettings` now manages:
  - preset choices and sanitization
  - preset palette resolution
  - merged style options (`defaults + preset + custom`)
- `ShopFilters` now outputs skin-aware wrapper classes (`wf-skin-{slug}`)
- CSS adds skin-specific visual signatures for Graphite and Sunrise presets

## Validation
- php syntax checks passed:
  - `php -l src/StyleSettings.php`
  - `php -l src/ShopFilters.php`
  - `php -l src/Plugin.php`
  - `php -l woo-filters.php`
- manual review completed for settings persistence and frontend class rendering in both archive and shortcode contexts

Closes #13