### PR TITLE
feat: add mobile off-canvas drawer for shop filters

### DIFF
--- a/assets/css/wf-shop.css
+++ b/assets/css/wf-shop.css
@@ -17,6 +17,12 @@
   font-size: var(--wf-font-size);
 }
 
+.wf-filter-toggle,
+.wf-sidebar-overlay,
+.wf-sidebar-close {
+  display: none;
+}
+
 .wf-sidebar {
   background: var(--wf-sidebar-bg);
   border: 1px solid var(--wf-sidebar-border);
@@ -25,6 +31,10 @@
   position: sticky;
   top: 20px;
   align-self: start;
+}
+
+body.wf-no-scroll {
+  overflow: hidden;
 }
 
 .wf-shop-layout {
@@ -409,8 +419,69 @@
     grid-template-columns: 1fr;
   }
 
+  .wf-filter-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: fit-content;
+    min-height: 40px;
+    padding: 0 14px;
+    border: 1px solid var(--wf-sidebar-border);
+    border-radius: 8px;
+    background: #fff;
+    color: var(--wf-heading-color);
+    font-weight: 600;
+    cursor: pointer;
+  }
+
+  .wf-sidebar-overlay {
+    display: block;
+    position: fixed;
+    inset: 0;
+    z-index: 9997;
+    background: rgba(17, 24, 39, 0.46);
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.22s ease, visibility 0.22s ease;
+  }
+
   .wf-sidebar {
-    position: static;
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 9998;
+    width: min(86vw, 340px);
+    height: 100dvh;
+    border-radius: 0 12px 12px 0;
+    overflow-y: auto;
+    transform: translateX(-105%);
+    transition: transform 0.24s ease;
+    box-shadow: 0 12px 28px rgba(0, 0, 0, 0.2);
+  }
+
+  .wf-sidebar-close {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 34px;
+    height: 34px;
+    margin: -6px 0 8px auto;
+    border: 1px solid var(--wf-sidebar-border);
+    border-radius: 999px;
+    background: #fff;
+    color: var(--wf-heading-color);
+    font-size: 20px;
+    line-height: 1;
+    cursor: pointer;
+  }
+
+  .wf-shop-layout.wf-drawer-open .wf-sidebar {
+    transform: translateX(0);
+  }
+
+  .wf-shop-layout.wf-drawer-open .wf-sidebar-overlay {
+    opacity: 1;
+    visibility: visible;
   }
 
   .wf-products ul.products {

--- a/assets/js/wf-shop.js
+++ b/assets/js/wf-shop.js
@@ -8,6 +8,8 @@
 
   var priceDebounceTimer = null;
   var currentController = null;
+  var isDrawerOpen = false;
+  var mobileBreakpoint = window.matchMedia('(max-width: 860px)');
   var requestNonce =
     typeof window.wfShopFilters === 'object' && window.wfShopFilters && window.wfShopFilters.nonce
       ? String(window.wfShopFilters.nonce)
@@ -15,6 +17,27 @@
 
   function setLoading(isLoading) {
     layout.classList.toggle('wf-is-loading', !!isLoading);
+  }
+
+  function setDrawerState(nextState) {
+    isDrawerOpen = !!nextState;
+    layout.classList.toggle('wf-drawer-open', isDrawerOpen);
+    document.body.classList.toggle('wf-no-scroll', isDrawerOpen);
+
+    var toggle = layout.querySelector('.wf-filter-toggle');
+    if (toggle) {
+      toggle.setAttribute('aria-expanded', isDrawerOpen ? 'true' : 'false');
+    }
+  }
+
+  function closeDrawer() {
+    setDrawerState(false);
+  }
+
+  function initMobileDrawer() {
+    if (!mobileBreakpoint.matches) {
+      closeDrawer();
+    }
   }
 
   function isPrimaryClick(event) {
@@ -296,6 +319,7 @@
       })
       .then(function (html) {
         swapFromResponse(html);
+        closeDrawer();
 
         if (opts.pushState !== false) {
           window.history.pushState({ wf: true }, '', url);
@@ -382,6 +406,23 @@
   });
 
   layout.addEventListener('click', function (event) {
+    var target = event.target;
+    if (!(target instanceof Element)) {
+      return;
+    }
+
+    if (target.closest('.wf-filter-toggle')) {
+      event.preventDefault();
+      setDrawerState(!isDrawerOpen);
+      return;
+    }
+
+    if (target.closest('.wf-sidebar-close') || target.closest('.wf-sidebar-overlay')) {
+      event.preventDefault();
+      closeDrawer();
+      return;
+    }
+
     var link = event.target.closest('a');
     if (!link || !isPrimaryClick(event) || !isNavigableLink(link)) {
       return;
@@ -400,6 +441,23 @@
     requestAndSwap(window.location.href, { pushState: false });
   });
 
+  document.addEventListener('keydown', function (event) {
+    if ('Escape' === event.key) {
+      closeDrawer();
+    }
+  });
+
+  if (typeof mobileBreakpoint.addEventListener === 'function') {
+    mobileBreakpoint.addEventListener('change', function () {
+      initMobileDrawer();
+    });
+  } else if (typeof mobileBreakpoint.addListener === 'function') {
+    mobileBreakpoint.addListener(function () {
+      initMobileDrawer();
+    });
+  }
+
   initPriceSliders();
   initOptionSearch();
+  initMobileDrawer();
 })();

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -41,7 +41,7 @@ final class Plugin {
 	 *
 	 * @var string
 	 */
-	private $version = '0.8.0';
+	private $version = '0.9.0';
 
 	/**
 	 * Shop filters service.

--- a/src/ShopFilters.php
+++ b/src/ShopFilters.php
@@ -284,7 +284,10 @@ final class ShopFilters {
 
 		ob_start();
 		echo '<div class="wf-shop-layout wf-shortcode-layout ' . esc_attr( $skin_class ) . '">';
+		echo '<button type="button" class="wf-filter-toggle" aria-expanded="false">' . esc_html__( 'Filters', 'woo-filters' ) . '</button>';
+		echo '<div class="wf-sidebar-overlay" aria-hidden="true"></div>';
 		echo '<aside class="wf-sidebar">';
+		echo '<button type="button" class="wf-sidebar-close" aria-label="' . esc_attr__( 'Close filters', 'woo-filters' ) . '">&times;</button>';
 		$this->render_filter_form();
 		echo '</aside>';
 		echo '<section class="wf-products">';
@@ -322,7 +325,10 @@ final class ShopFilters {
 		}
 
 		echo '<div class="wf-shop-layout ' . esc_attr( $this->get_layout_skin_class() ) . '">';
+		echo '<button type="button" class="wf-filter-toggle" aria-expanded="false">' . esc_html__( 'Filters', 'woo-filters' ) . '</button>';
+		echo '<div class="wf-sidebar-overlay" aria-hidden="true"></div>';
 		echo '<aside class="wf-sidebar">';
+		echo '<button type="button" class="wf-sidebar-close" aria-label="' . esc_attr__( 'Close filters', 'woo-filters' ) . '">&times;</button>';
 		$this->render_filter_form();
 		echo '</aside>';
 		echo '<section class="wf-products">';

--- a/woo-filters.php
+++ b/woo-filters.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Woo Filters
  * Description: Shop/archive filters for WooCommerce.
- * Version: 0.8.0
+ * Version: 0.9.0
  * Author: Anisur Rahman
  * Author URI: https://github.com/anisur2805
  * Requires at least: 6.0


### PR DESCRIPTION
## Summary
- add a mobile-first off-canvas drawer for filter sidebar on small screens
- add `Filters` toggle button, overlay backdrop, and close button
- support drawer close interactions via overlay click, close button, and `Esc` key
- close drawer automatically after AJAX filter navigation completes
- keep desktop behavior unchanged
- bump plugin version to 0.9.0

## Implementation Details
- `ShopFilters` now renders mobile drawer controls in both archive and shortcode layouts
- JS introduces drawer state management with body scroll lock and breakpoint-aware reset
- CSS adds responsive drawer styles under `max-width: 860px` with slide-in transition
- includes compatibility fallback for media query listeners (`addEventListener` / `addListener`)

## Validation
- php syntax checks passed:
  - `php -l src/ShopFilters.php`
  - `php -l src/Plugin.php`
  - `php -l woo-filters.php`
- manual code review completed for AJAX + mobile drawer interaction flow

Closes #1