### PR TITLE
feat: add admin settings screen for filter block configuration

### DIFF
--- a/src/FilterSettings.php
+++ b/src/FilterSettings.php
@@ -1,0 +1,197 @@
+<?php
+/**
+ * Filter settings controller.
+ *
+ * @package WooFilters
+ */
+
+namespace WooFilters;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Registers admin settings for filter visibility configuration.
+ */
+final class FilterSettings {
+	/** @var string */
+	private const OPTION_KEY = 'wf_filter_options';
+
+	/** @var string */
+	private const PAGE_SLUG = 'wf-filter-settings';
+
+	/**
+	 * Register class hooks.
+	 *
+	 * @return void
+	 */
+	public function register_hooks(): void {
+		add_action( 'admin_init', array( $this, 'register_settings' ) );
+		add_action( 'admin_menu', array( $this, 'register_menu' ) );
+	}
+
+	/**
+	 * Register settings and fields.
+	 *
+	 * @return void
+	 */
+	public function register_settings(): void {
+		register_setting(
+			'wf_filter_settings',
+			self::OPTION_KEY,
+			array(
+				'type'              => 'array',
+				'sanitize_callback' => array( $this, 'sanitize_settings' ),
+				'default'           => self::get_defaults(),
+			)
+		);
+
+		add_settings_section(
+			'wf_filter_section_main',
+			__( 'Filter Visibility', 'woo-filters' ),
+			array( $this, 'render_section_intro' ),
+			self::PAGE_SLUG
+		);
+
+		$this->register_checkbox_field( 'show_categories', __( 'Show Categories', 'woo-filters' ) );
+		$this->register_checkbox_field( 'show_brands', __( 'Show Brands', 'woo-filters' ) );
+		$this->register_checkbox_field( 'show_price', __( 'Show Price', 'woo-filters' ) );
+		$this->register_checkbox_field( 'show_rating', __( 'Show Customer Rating', 'woo-filters' ) );
+		$this->register_checkbox_field( 'show_availability', __( 'Show Availability', 'woo-filters' ) );
+		$this->register_checkbox_field( 'show_colors', __( 'Show Color', 'woo-filters' ) );
+	}
+
+	/**
+	 * Register submenu page under WooCommerce.
+	 *
+	 * @return void
+	 */
+	public function register_menu(): void {
+		add_submenu_page(
+			'woocommerce',
+			__( 'Woo Filters Settings', 'woo-filters' ),
+			__( 'Woo Filters Settings', 'woo-filters' ),
+			'manage_woocommerce',
+			self::PAGE_SLUG,
+			array( $this, 'render_page' )
+		);
+	}
+
+	/**
+	 * Render settings page.
+	 *
+	 * @return void
+	 */
+	public function render_page(): void {
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			return;
+		}
+
+		echo '<div class="wrap">';
+		echo '<h1>' . esc_html__( 'Woo Filters Settings', 'woo-filters' ) . '</h1>';
+		echo '<form action="options.php" method="post">';
+		settings_fields( 'wf_filter_settings' );
+		do_settings_sections( self::PAGE_SLUG );
+		submit_button( __( 'Save Settings', 'woo-filters' ) );
+		echo '</form>';
+		echo '</div>';
+	}
+
+	/**
+	 * Render section intro.
+	 *
+	 * @return void
+	 */
+	public function render_section_intro(): void {
+		echo '<p>' . esc_html__( 'Enable or disable individual filter blocks in the shop sidebar.', 'woo-filters' ) . '</p>';
+	}
+
+	/**
+	 * Register checkbox field.
+	 *
+	 * @param string $key   Option key.
+	 * @param string $label Option label.
+	 * @return void
+	 */
+	private function register_checkbox_field( string $key, string $label ): void {
+		add_settings_field(
+			$key,
+			$label,
+			array( $this, 'render_checkbox_field' ),
+			self::PAGE_SLUG,
+			'wf_filter_section_main',
+			array(
+				'key' => $key,
+			)
+		);
+	}
+
+	/**
+	 * Render checkbox input.
+	 *
+	 * @param array $args Field args.
+	 * @return void
+	 */
+	public function render_checkbox_field( array $args ): void {
+		$key     = isset( $args['key'] ) ? sanitize_key( (string) $args['key'] ) : '';
+		$options = self::get_options();
+		$checked = isset( $options[ $key ] ) && 'yes' === $options[ $key ];
+
+		echo '<label>';
+		echo '<input type="checkbox" name="' . esc_attr( self::OPTION_KEY ) . '[' . esc_attr( $key ) . ']" value="yes" ' . checked( $checked, true, false ) . ' />';
+		echo ' ' . esc_html__( 'Enabled', 'woo-filters' );
+		echo '</label>';
+	}
+
+	/**
+	 * Sanitize incoming option payload.
+	 *
+	 * @param mixed $raw Raw value.
+	 * @return array
+	 */
+	public function sanitize_settings( $raw ): array {
+		$defaults  = self::get_defaults();
+		$sanitized = array();
+
+		if ( ! is_array( $raw ) ) {
+			return $defaults;
+		}
+
+		foreach ( array_keys( $defaults ) as $key ) {
+			$sanitized[ $key ] = ( isset( $raw[ $key ] ) && 'yes' === sanitize_text_field( wp_unslash( (string) $raw[ $key ] ) ) ) ? 'yes' : 'no';
+		}
+
+		return $sanitized;
+	}
+
+	/**
+	 * Get merged options.
+	 *
+	 * @return array
+	 */
+	public static function get_options(): array {
+		$options = get_option( self::OPTION_KEY, array() );
+		if ( ! is_array( $options ) ) {
+			$options = array();
+		}
+
+		return array_merge( self::get_defaults(), $options );
+	}
+
+	/**
+	 * Default options.
+	 *
+	 * @return array
+	 */
+	private static function get_defaults(): array {
+		return array(
+			'show_categories'   => 'yes',
+			'show_brands'       => 'yes',
+			'show_price'        => 'yes',
+			'show_rating'       => 'yes',
+			'show_availability' => 'yes',
+			'show_colors'       => 'yes',
+		);
+	}
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -41,7 +41,7 @@ final class Plugin {
 	 *
 	 * @var string
 	 */
-	private $version = '0.8.0';
+	private $version = '0.9.0';
 
 	/**
 	 * Shop filters service.
@@ -56,6 +56,13 @@ final class Plugin {
 	 * @var StyleSettings|null
 	 */
 	private $style_settings = null;
+
+	/**
+	 * Filter settings service.
+	 *
+	 * @var FilterSettings|null
+	 */
+	private $filter_settings = null;
 
 	/**
 	 * Constructor.
@@ -96,5 +103,8 @@ final class Plugin {
 
 		$this->style_settings = new StyleSettings();
 		$this->style_settings->register_hooks();
+
+		$this->filter_settings = new FilterSettings();
+		$this->filter_settings->register_hooks();
 	}
 }

--- a/src/ShopFilters.php
+++ b/src/ShopFilters.php
@@ -433,6 +433,14 @@ final class ShopFilters {
 	 * @return void
 	 */
 	private function render_filter_form(): void {
+		$filter_options  = FilterSettings::get_options();
+		$show_categories = isset( $filter_options['show_categories'] ) && 'yes' === $filter_options['show_categories'];
+		$show_brands     = isset( $filter_options['show_brands'] ) && 'yes' === $filter_options['show_brands'];
+		$show_price      = isset( $filter_options['show_price'] ) && 'yes' === $filter_options['show_price'];
+		$show_rating     = isset( $filter_options['show_rating'] ) && 'yes' === $filter_options['show_rating'];
+		$show_stock      = isset( $filter_options['show_availability'] ) && 'yes' === $filter_options['show_availability'];
+		$show_colors     = isset( $filter_options['show_colors'] ) && 'yes' === $filter_options['show_colors'];
+
 		$action          = $this->get_archive_url();
 		$selected_brands = $this->get_request_slug_list( 'wf_brand' );
 		$selected_colors = $this->get_request_slug_list( 'wf_color' );
@@ -458,54 +466,62 @@ final class ShopFilters {
 		$this->render_preserved_fields( array( 'wf_cat', 'wf_brand', 'wf_color', 'min_price', 'max_price', 'rating_filter', 'wf_in_stock', 'wf_on_sale', 'paged', 'product-page' ) );
 		$this->render_active_filters();
 
-		echo '<div class="wf-filter-block">';
-		echo '<h4>' . esc_html__( 'Categories', 'woo-filters' ) . '</h4>';
-		$this->render_categories();
-		echo '</div>';
+		if ( $show_categories ) {
+			echo '<div class="wf-filter-block">';
+			echo '<h4>' . esc_html__( 'Categories', 'woo-filters' ) . '</h4>';
+			$this->render_categories();
+			echo '</div>';
+		}
 
-		if ( '' !== $this->brand_taxonomy ) {
+		if ( $show_brands && '' !== $this->brand_taxonomy ) {
 			echo '<div class="wf-filter-block">';
 			echo '<h4>' . esc_html__( 'Filter by Brands', 'woo-filters' ) . '</h4>';
 			$this->render_term_checkboxes( $this->brand_taxonomy, 'wf_brand[]', 'wf_brand', $selected_brands );
 			echo '</div>';
 		}
 
-		echo '<div class="wf-filter-block">';
-		echo '<h4>' . esc_html__( 'Price', 'woo-filters' ) . '</h4>';
-		echo '<div class="wf-price-slider" data-min="' . esc_attr( $this->format_decimal_for_input( $slider_min ) ) . '" data-max="' . esc_attr( $this->format_decimal_for_input( $slider_max ) ) . '" data-step="0.01">';
-		echo '<div class="wf-price-range-inputs">';
-		echo '<input class="wf-price-range wf-price-range-min" type="range" aria-label="' . esc_attr__( 'Minimum price', 'woo-filters' ) . '" min="' . esc_attr( $this->format_decimal_for_input( $slider_min ) ) . '" max="' . esc_attr( $this->format_decimal_for_input( $slider_max ) ) . '" step="0.01" value="' . esc_attr( $this->format_decimal_for_input( $current_min ) ) . '" />';
-		echo '<input class="wf-price-range wf-price-range-max" type="range" aria-label="' . esc_attr__( 'Maximum price', 'woo-filters' ) . '" min="' . esc_attr( $this->format_decimal_for_input( $slider_min ) ) . '" max="' . esc_attr( $this->format_decimal_for_input( $slider_max ) ) . '" step="0.01" value="' . esc_attr( $this->format_decimal_for_input( $current_max ) ) . '" />';
-		echo '</div>';
-		echo '<div class="wf-price-track"><span class="wf-price-track-fill"></span></div>';
-		echo '</div>';
-		echo '<div class="wf-price-grid">';
-		echo '<label><span>' . esc_html__( 'Min', 'woo-filters' ) . '</span><input type="number" min="' . esc_attr( $this->format_decimal_for_input( $slider_min ) ) . '" max="' . esc_attr( $this->format_decimal_for_input( $slider_max ) ) . '" step="0.01" name="min_price" value="' . esc_attr( $this->format_decimal_for_input( $min_price ) ) . '" placeholder="' . esc_attr( $this->format_decimal_for_input( $slider_min ) ) . '" /></label>';
-		echo '<label><span>' . esc_html__( 'Max', 'woo-filters' ) . '</span><input type="number" min="' . esc_attr( $this->format_decimal_for_input( $slider_min ) ) . '" max="' . esc_attr( $this->format_decimal_for_input( $slider_max ) ) . '" step="0.01" name="max_price" value="' . esc_attr( $this->format_decimal_for_input( $max_price ) ) . '" placeholder="' . esc_attr( $this->format_decimal_for_input( $slider_max ) ) . '" /></label>';
-		echo '</div>';
-		echo '</div>';
-
-		echo '<div class="wf-filter-block">';
-		echo '<h4>' . esc_html__( 'Customer Rating', 'woo-filters' ) . '</h4>';
-		for ( $i = 5; $i >= 1; $i-- ) {
-			echo '<label class="wf-radio">';
-			echo '<input type="radio" name="rating_filter" value="' . esc_attr( (string) $i ) . '" ' . checked( $selected_rating, $i, false ) . ' />';
-			echo '<span>' . esc_html( sprintf( __( '%d stars & up', 'woo-filters' ), $i ) ) . '</span>';
-			echo '</label>';
+		if ( $show_price ) {
+			echo '<div class="wf-filter-block">';
+			echo '<h4>' . esc_html__( 'Price', 'woo-filters' ) . '</h4>';
+			echo '<div class="wf-price-slider" data-min="' . esc_attr( $this->format_decimal_for_input( $slider_min ) ) . '" data-max="' . esc_attr( $this->format_decimal_for_input( $slider_max ) ) . '" data-step="0.01">';
+			echo '<div class="wf-price-range-inputs">';
+			echo '<input class="wf-price-range wf-price-range-min" type="range" aria-label="' . esc_attr__( 'Minimum price', 'woo-filters' ) . '" min="' . esc_attr( $this->format_decimal_for_input( $slider_min ) ) . '" max="' . esc_attr( $this->format_decimal_for_input( $slider_max ) ) . '" step="0.01" value="' . esc_attr( $this->format_decimal_for_input( $current_min ) ) . '" />';
+			echo '<input class="wf-price-range wf-price-range-max" type="range" aria-label="' . esc_attr__( 'Maximum price', 'woo-filters' ) . '" min="' . esc_attr( $this->format_decimal_for_input( $slider_min ) ) . '" max="' . esc_attr( $this->format_decimal_for_input( $slider_max ) ) . '" step="0.01" value="' . esc_attr( $this->format_decimal_for_input( $current_max ) ) . '" />';
+			echo '</div>';
+			echo '<div class="wf-price-track"><span class="wf-price-track-fill"></span></div>';
+			echo '</div>';
+			echo '<div class="wf-price-grid">';
+			echo '<label><span>' . esc_html__( 'Min', 'woo-filters' ) . '</span><input type="number" min="' . esc_attr( $this->format_decimal_for_input( $slider_min ) ) . '" max="' . esc_attr( $this->format_decimal_for_input( $slider_max ) ) . '" step="0.01" name="min_price" value="' . esc_attr( $this->format_decimal_for_input( $min_price ) ) . '" placeholder="' . esc_attr( $this->format_decimal_for_input( $slider_min ) ) . '" /></label>';
+			echo '<label><span>' . esc_html__( 'Max', 'woo-filters' ) . '</span><input type="number" min="' . esc_attr( $this->format_decimal_for_input( $slider_min ) ) . '" max="' . esc_attr( $this->format_decimal_for_input( $slider_max ) ) . '" step="0.01" name="max_price" value="' . esc_attr( $this->format_decimal_for_input( $max_price ) ) . '" placeholder="' . esc_attr( $this->format_decimal_for_input( $slider_max ) ) . '" /></label>';
+			echo '</div>';
+			echo '</div>';
 		}
-		echo '<label class="wf-radio">';
-		echo '<input type="radio" name="rating_filter" value="" ' . checked( $selected_rating, 0, false ) . ' />';
-		echo '<span>' . esc_html__( 'Any', 'woo-filters' ) . '</span>';
-		echo '</label>';
-		echo '</div>';
 
-		echo '<div class="wf-filter-block">';
-		echo '<h4>' . esc_html__( 'Availability', 'woo-filters' ) . '</h4>';
-		echo '<label class="wf-radio"><input type="checkbox" name="wf_in_stock" value="1" ' . checked( $in_stock_only, true, false ) . ' /> <span>' . esc_html__( 'In stock only', 'woo-filters' ) . '</span></label>';
-		echo '<label class="wf-radio"><input type="checkbox" name="wf_on_sale" value="1" ' . checked( $on_sale_only, true, false ) . ' /> <span>' . esc_html__( 'On sale only', 'woo-filters' ) . '</span></label>';
-		echo '</div>';
+		if ( $show_rating ) {
+			echo '<div class="wf-filter-block">';
+			echo '<h4>' . esc_html__( 'Customer Rating', 'woo-filters' ) . '</h4>';
+			for ( $i = 5; $i >= 1; $i-- ) {
+				echo '<label class="wf-radio">';
+				echo '<input type="radio" name="rating_filter" value="' . esc_attr( (string) $i ) . '" ' . checked( $selected_rating, $i, false ) . ' />';
+				echo '<span>' . esc_html( sprintf( __( '%d stars & up', 'woo-filters' ), $i ) ) . '</span>';
+				echo '</label>';
+			}
+			echo '<label class="wf-radio">';
+			echo '<input type="radio" name="rating_filter" value="" ' . checked( $selected_rating, 0, false ) . ' />';
+			echo '<span>' . esc_html__( 'Any', 'woo-filters' ) . '</span>';
+			echo '</label>';
+			echo '</div>';
+		}
 
-		if ( '' !== $this->color_taxonomy ) {
+		if ( $show_stock ) {
+			echo '<div class="wf-filter-block">';
+			echo '<h4>' . esc_html__( 'Availability', 'woo-filters' ) . '</h4>';
+			echo '<label class="wf-radio"><input type="checkbox" name="wf_in_stock" value="1" ' . checked( $in_stock_only, true, false ) . ' /> <span>' . esc_html__( 'In stock only', 'woo-filters' ) . '</span></label>';
+			echo '<label class="wf-radio"><input type="checkbox" name="wf_on_sale" value="1" ' . checked( $on_sale_only, true, false ) . ' /> <span>' . esc_html__( 'On sale only', 'woo-filters' ) . '</span></label>';
+			echo '</div>';
+		}
+
+		if ( $show_colors && '' !== $this->color_taxonomy ) {
 			echo '<div class="wf-filter-block">';
 			echo '<h4>' . esc_html__( 'Color', 'woo-filters' ) . '</h4>';
 			$this->render_term_checkboxes( $this->color_taxonomy, 'wf_color[]', 'wf_color', $selected_colors );
@@ -548,10 +564,11 @@ final class ShopFilters {
 	 * @return array
 	 */
 	private function get_active_filter_chips(): array {
+		$filter_options = FilterSettings::get_options();
 		$chips = array();
 
 		$selected_category = $this->get_request_slug( 'wf_cat' );
-		if ( '' !== $selected_category ) {
+		if ( isset( $filter_options['show_categories'] ) && 'yes' === $filter_options['show_categories'] && '' !== $selected_category ) {
 			$term = get_term_by( 'slug', $selected_category, 'product_cat' );
 			if ( $term instanceof \WP_Term ) {
 				$chips[] = array(
@@ -561,11 +578,15 @@ final class ShopFilters {
 			}
 		}
 
-		$chips = array_merge( $chips, $this->get_term_chips_from_selected( $this->brand_taxonomy, 'wf_brand', __( 'Brand', 'woo-filters' ) ) );
-		$chips = array_merge( $chips, $this->get_term_chips_from_selected( $this->color_taxonomy, 'wf_color', __( 'Color', 'woo-filters' ) ) );
+		if ( isset( $filter_options['show_brands'] ) && 'yes' === $filter_options['show_brands'] ) {
+			$chips = array_merge( $chips, $this->get_term_chips_from_selected( $this->brand_taxonomy, 'wf_brand', __( 'Brand', 'woo-filters' ) ) );
+		}
+		if ( isset( $filter_options['show_colors'] ) && 'yes' === $filter_options['show_colors'] ) {
+			$chips = array_merge( $chips, $this->get_term_chips_from_selected( $this->color_taxonomy, 'wf_color', __( 'Color', 'woo-filters' ) ) );
+		}
 
 		$min_price = $this->get_request_decimal( 'min_price' );
-		if ( null !== $min_price ) {
+		if ( isset( $filter_options['show_price'] ) && 'yes' === $filter_options['show_price'] && null !== $min_price ) {
 			$chips[] = array(
 				'label' => sprintf( __( 'Min: %s', 'woo-filters' ), wp_strip_all_tags( wc_price( (float) $min_price ), true ) ),
 				'url'   => $this->build_remove_filter_url( 'min_price' ),
@@ -573,7 +594,7 @@ final class ShopFilters {
 		}
 
 		$max_price = $this->get_request_decimal( 'max_price' );
-		if ( null !== $max_price ) {
+		if ( isset( $filter_options['show_price'] ) && 'yes' === $filter_options['show_price'] && null !== $max_price ) {
 			$chips[] = array(
 				'label' => sprintf( __( 'Max: %s', 'woo-filters' ), wp_strip_all_tags( wc_price( (float) $max_price ), true ) ),
 				'url'   => $this->build_remove_filter_url( 'max_price' ),
@@ -581,21 +602,21 @@ final class ShopFilters {
 		}
 
 		$rating = $this->get_request_absint( 'rating_filter' );
-		if ( $rating > 0 && $rating <= 5 ) {
+		if ( isset( $filter_options['show_rating'] ) && 'yes' === $filter_options['show_rating'] && $rating > 0 && $rating <= 5 ) {
 			$chips[] = array(
 				'label' => sprintf( __( '%d stars & up', 'woo-filters' ), $rating ),
 				'url'   => $this->build_remove_filter_url( 'rating_filter' ),
 			);
 		}
 
-		if ( $this->get_request_flag( 'wf_in_stock' ) ) {
+		if ( isset( $filter_options['show_availability'] ) && 'yes' === $filter_options['show_availability'] && $this->get_request_flag( 'wf_in_stock' ) ) {
 			$chips[] = array(
 				'label' => __( 'Stock: In stock', 'woo-filters' ),
 				'url'   => $this->build_remove_filter_url( 'wf_in_stock' ),
 			);
 		}
 
-		if ( $this->get_request_flag( 'wf_on_sale' ) ) {
+		if ( isset( $filter_options['show_availability'] ) && 'yes' === $filter_options['show_availability'] && $this->get_request_flag( 'wf_on_sale' ) ) {
 			$chips[] = array(
 				'label' => __( 'Sale: On sale', 'woo-filters' ),
 				'url'   => $this->build_remove_filter_url( 'wf_on_sale' ),
@@ -1135,12 +1156,13 @@ final class ShopFilters {
 	 * @return array{tax: array, meta: array}
 	 */
 	private function get_request_filter_clauses( array $exclude_keys = array() ): array {
+		$filter_options = FilterSettings::get_options();
 		$excluded = array_fill_keys( $exclude_keys, true );
 
 		$tax_clauses  = array();
 		$meta_clauses = array();
 
-		if ( ! isset( $excluded['wf_cat'] ) ) {
+		if ( ! isset( $excluded['wf_cat'] ) && isset( $filter_options['show_categories'] ) && 'yes' === $filter_options['show_categories'] ) {
 			$selected_category = $this->get_request_slug( 'wf_cat' );
 			if ( '' !== $selected_category ) {
 				$tax_clauses[] = array(
@@ -1151,7 +1173,7 @@ final class ShopFilters {
 			}
 		}
 
-		if ( ! isset( $excluded['wf_brand'] ) ) {
+		if ( ! isset( $excluded['wf_brand'] ) && isset( $filter_options['show_brands'] ) && 'yes' === $filter_options['show_brands'] ) {
 			$selected_brands = $this->get_request_slug_list( 'wf_brand' );
 			if ( '' !== $this->brand_taxonomy && ! empty( $selected_brands ) ) {
 				$tax_clauses[] = array(
@@ -1163,7 +1185,7 @@ final class ShopFilters {
 			}
 		}
 
-		if ( ! isset( $excluded['wf_color'] ) ) {
+		if ( ! isset( $excluded['wf_color'] ) && isset( $filter_options['show_colors'] ) && 'yes' === $filter_options['show_colors'] ) {
 			$selected_colors = $this->get_request_slug_list( 'wf_color' );
 			if ( '' !== $this->color_taxonomy && ! empty( $selected_colors ) ) {
 				$tax_clauses[] = array(
@@ -1175,7 +1197,7 @@ final class ShopFilters {
 			}
 		}
 
-		if ( ! isset( $excluded['min_price'] ) || ! isset( $excluded['max_price'] ) ) {
+		if ( ( ! isset( $excluded['min_price'] ) || ! isset( $excluded['max_price'] ) ) && isset( $filter_options['show_price'] ) && 'yes' === $filter_options['show_price'] ) {
 			$min_price = $this->get_request_decimal( 'min_price' );
 			$max_price = $this->get_request_decimal( 'max_price' );
 
@@ -1198,7 +1220,7 @@ final class ShopFilters {
 			}
 		}
 
-		if ( ! isset( $excluded['rating_filter'] ) ) {
+		if ( ! isset( $excluded['rating_filter'] ) && isset( $filter_options['show_rating'] ) && 'yes' === $filter_options['show_rating'] ) {
 			$rating = $this->get_request_absint( 'rating_filter' );
 			if ( $rating > 0 && $rating <= 5 ) {
 				$meta_clauses[] = array(
@@ -1210,7 +1232,7 @@ final class ShopFilters {
 			}
 		}
 
-		if ( ! isset( $excluded['wf_in_stock'] ) && $this->get_request_flag( 'wf_in_stock' ) ) {
+		if ( ! isset( $excluded['wf_in_stock'] ) && isset( $filter_options['show_availability'] ) && 'yes' === $filter_options['show_availability'] && $this->get_request_flag( 'wf_in_stock' ) ) {
 			$meta_clauses[] = array(
 				'key'     => '_stock_status',
 				'value'   => 'instock',
@@ -1218,7 +1240,7 @@ final class ShopFilters {
 			);
 		}
 
-		if ( ! isset( $excluded['wf_on_sale'] ) && $this->get_request_flag( 'wf_on_sale' ) ) {
+		if ( ! isset( $excluded['wf_on_sale'] ) && isset( $filter_options['show_availability'] ) && 'yes' === $filter_options['show_availability'] && $this->get_request_flag( 'wf_on_sale' ) ) {
 			$meta_clauses[] = array(
 				'key'     => '_sale_price',
 				'value'   => 0,

--- a/woo-filters.php
+++ b/woo-filters.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Woo Filters
  * Description: Shop/archive filters for WooCommerce.
- * Version: 0.8.0
+ * Version: 0.9.0
  * Author: Anisur Rahman
  * Author URI: https://github.com/anisur2805
  * Requires at least: 6.0


### PR DESCRIPTION
## Summary
- add a dedicated WooCommerce submenu page: `Woo Filters Settings`
- allow enabling/disabling individual filter blocks:
  - Categories
  - Brands
  - Price
  - Customer Rating
  - Availability
  - Color
- wire settings into sidebar rendering so hidden blocks are not output
- harden query behavior so disabled filters are ignored even if present in URL
- align active-filter chips with enabled filter blocks only
- bump plugin version to 0.9.0

## Technical Details
- new class: `WooFilters\\FilterSettings`
  - Settings API registration
  - option sanitization (`yes` / `no`)
  - defaults + merged option access
- plugin container now boots `FilterSettings` alongside existing services
- `ShopFilters` uses `FilterSettings::get_options()` in:
  - `render_filter_form()`
  - `get_active_filter_chips()`
  - `get_request_filter_clauses()`

## Validation
- php syntax checks passed:
  - `php -l src/FilterSettings.php`
  - `php -l src/ShopFilters.php`
  - `php -l src/Plugin.php`
  - `php -l woo-filters.php`
- manual code review completed for disabled-filter query bypass prevention

Closes #7