### PR TITLE
feat: add custom attribute filters with color swatch rendering

### DIFF
--- a/assets/css/wf-shop.css
+++ b/assets/css/wf-shop.css
@@ -110,6 +110,14 @@ body.wf-no-scroll {
   color: #5b6472;
 }
 
+.wf-color-swatch {
+  width: 14px;
+  height: 14px;
+  border-radius: 999px;
+  border: 1px solid #cdd5df;
+  flex: 0 0 14px;
+}
+
 .wf-cat-list small {
   margin-left: auto;
   color: #5b6472;

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -41,7 +41,7 @@ final class Plugin {
 	 *
 	 * @var string
 	 */
-	private $version = '0.10.0';
+	private $version = '0.11.0';
 
 	/**
 	 * Shop filters service.

--- a/src/ShopFilters.php
+++ b/src/ShopFilters.php
@@ -36,6 +36,9 @@ final class ShopFilters {
 	/** @var string */
 	private $color_taxonomy = '';
 
+	/** @var array<int, string> */
+	private $custom_attribute_taxonomies = array();
+
 	/** @var string */
 	private $plugin_url = '';
 
@@ -109,6 +112,7 @@ final class ShopFilters {
 	public function bootstrap_taxonomies(): void {
 		$this->brand_taxonomy = $this->resolve_taxonomy( array( 'pa_brand', 'product_brand', 'brand' ) );
 		$this->color_taxonomy = $this->resolve_taxonomy( array( 'pa_color', 'color' ) );
+		$this->custom_attribute_taxonomies = $this->get_filterable_attribute_taxonomies();
 	}
 
 	/**
@@ -450,6 +454,11 @@ final class ShopFilters {
 		$action          = $this->get_archive_url();
 		$selected_brands  = $this->get_request_slug_list( 'wf_brand' );
 		$selected_colors  = $this->get_request_slug_list( 'wf_color' );
+		$selected_attributes = array();
+		foreach ( $this->custom_attribute_taxonomies as $attribute_taxonomy ) {
+			$request_key = $this->get_attribute_request_key( $attribute_taxonomy );
+			$selected_attributes[ $request_key ] = $this->get_request_slug_list( $request_key );
+		}
 		$multiselect_mode = $this->get_request_multiselect_mode();
 		$selected_rating = $this->get_request_absint( 'rating_filter' );
 		$min_price       = $this->get_request_decimal( 'min_price' );
@@ -470,7 +479,11 @@ final class ShopFilters {
 
 		echo '<form class="wf-filter-form" method="get" action="' . esc_url( $action ) . '">';
 		echo '<input type="hidden" name="wf_nonce" value="' . esc_attr( $this->get_filter_nonce() ) . '" />';
-		$this->render_preserved_fields( array( 'wf_cat', 'wf_brand', 'wf_color', 'wf_logic', 'min_price', 'max_price', 'rating_filter', 'wf_in_stock', 'wf_on_sale', 'paged', 'product-page' ) );
+		$excluded_preserved = array( 'wf_cat', 'wf_brand', 'wf_color', 'wf_logic', 'min_price', 'max_price', 'rating_filter', 'wf_in_stock', 'wf_on_sale', 'paged', 'product-page' );
+		foreach ( $this->custom_attribute_taxonomies as $attribute_taxonomy ) {
+			$excluded_preserved[] = $this->get_attribute_request_key( $attribute_taxonomy );
+		}
+		$this->render_preserved_fields( $excluded_preserved );
 		$this->render_active_filters();
 
 		if ( $show_categories ) {
@@ -535,7 +548,19 @@ final class ShopFilters {
 		if ( $show_colors && '' !== $this->color_taxonomy ) {
 			echo '<div class="wf-filter-block">';
 			echo '<h4>' . esc_html__( 'Color', 'woo-filters' ) . '</h4>';
-			$this->render_term_checkboxes( $this->color_taxonomy, 'wf_color[]', 'wf_color', $selected_colors );
+			$this->render_term_checkboxes( $this->color_taxonomy, 'wf_color[]', 'wf_color', $selected_colors, true );
+			echo '</div>';
+		}
+
+		foreach ( $this->custom_attribute_taxonomies as $attribute_taxonomy ) {
+			$request_key = $this->get_attribute_request_key( $attribute_taxonomy );
+			$field_name  = $request_key . '[]';
+			$selected    = isset( $selected_attributes[ $request_key ] ) && is_array( $selected_attributes[ $request_key ] ) ? $selected_attributes[ $request_key ] : array();
+			$is_color_attribute = $this->is_color_like_taxonomy( $attribute_taxonomy );
+
+			echo '<div class="wf-filter-block">';
+			echo '<h4>' . esc_html( $this->get_attribute_display_label( $attribute_taxonomy ) ) . '</h4>';
+			$this->render_term_checkboxes( $attribute_taxonomy, $field_name, $request_key, $selected, $is_color_attribute );
 			echo '</div>';
 		}
 
@@ -594,6 +619,11 @@ final class ShopFilters {
 		}
 		if ( isset( $filter_options['show_colors'] ) && 'yes' === $filter_options['show_colors'] ) {
 			$chips = array_merge( $chips, $this->get_term_chips_from_selected( $this->color_taxonomy, 'wf_color', __( 'Color', 'woo-filters' ) ) );
+		}
+		foreach ( $this->custom_attribute_taxonomies as $attribute_taxonomy ) {
+			$request_key = $this->get_attribute_request_key( $attribute_taxonomy );
+			$label       = $this->get_attribute_display_label( $attribute_taxonomy );
+			$chips       = array_merge( $chips, $this->get_term_chips_from_selected( $attribute_taxonomy, $request_key, $label ) );
 		}
 
 		$multiselect_mode = $this->get_request_multiselect_mode();
@@ -683,12 +713,14 @@ final class ShopFilters {
 	/**
 	 * Render checkbox list for a taxonomy.
 	 *
-	 * @param string $taxonomy        Taxonomy key.
-	 * @param string $field_name      HTML field name.
-	 * @param array  $selected_values Selected term slugs.
+	 * @param string $taxonomy           Taxonomy key.
+	 * @param string $field_name         HTML field name.
+	 * @param string $request_key        Request key.
+	 * @param array  $selected_values    Selected term slugs.
+	 * @param bool   $show_color_swatch  Whether to render color swatches.
 	 * @return void
 	 */
-	private function render_term_checkboxes( string $taxonomy, string $field_name, string $request_key, array $selected_values ): void {
+	private function render_term_checkboxes( string $taxonomy, string $field_name, string $request_key, array $selected_values, bool $show_color_swatch = false ): void {
 		$terms = $this->get_terms_cached(
 			array(
 				'taxonomy'   => $taxonomy,
@@ -723,6 +755,12 @@ final class ShopFilters {
 			echo '<li>';
 			echo '<label' . $label_c . '>';
 			echo '<input type="checkbox" name="' . esc_attr( $field_name ) . '" value="' . esc_attr( $term->slug ) . '"' . $disabled_a . ' ' . checked( $checked, true, false ) . ' />';
+			if ( $show_color_swatch ) {
+				$swatch_hex = $this->get_term_color_hex( $term );
+				if ( '' !== $swatch_hex ) {
+					echo '<span class="wf-color-swatch" style="background:' . esc_attr( $swatch_hex ) . ';"></span>';
+				}
+			}
 			echo '<span>' . esc_html( $term->name ) . '</span>';
 			echo '<small>' . esc_html( (string) $live_count ) . '</small>';
 			echo '</label>';
@@ -830,6 +868,20 @@ final class ShopFilters {
 				'taxonomy' => $this->color_taxonomy,
 				'field'    => 'slug',
 				'terms'    => $selected_colors,
+				'operator' => $tax_operator,
+			);
+		}
+		foreach ( $this->custom_attribute_taxonomies as $attribute_taxonomy ) {
+			$request_key = $this->get_attribute_request_key( $attribute_taxonomy );
+			$selected    = $this->get_request_slug_list( $request_key );
+			if ( empty( $selected ) ) {
+				continue;
+			}
+
+			$tax_clauses[] = array(
+				'taxonomy' => $attribute_taxonomy,
+				'field'    => 'slug',
+				'terms'    => $selected,
 				'operator' => $tax_operator,
 			);
 		}
@@ -1007,6 +1059,9 @@ final class ShopFilters {
 			$args['paged'],
 			$args['product-page']
 		);
+		foreach ( $this->custom_attribute_taxonomies as $attribute_taxonomy ) {
+			unset( $args[ $this->get_attribute_request_key( $attribute_taxonomy ) ] );
+		}
 
 		return add_query_arg( $this->with_security_args( $args ), $this->get_archive_url() );
 	}
@@ -1235,6 +1290,24 @@ final class ShopFilters {
 				);
 			}
 		}
+		foreach ( $this->custom_attribute_taxonomies as $attribute_taxonomy ) {
+			$request_key = $this->get_attribute_request_key( $attribute_taxonomy );
+			if ( isset( $excluded[ $request_key ] ) ) {
+				continue;
+			}
+
+			$selected_attribute_terms = $this->get_request_slug_list( $request_key );
+			if ( empty( $selected_attribute_terms ) ) {
+				continue;
+			}
+
+			$tax_clauses[] = array(
+				'taxonomy' => $attribute_taxonomy,
+				'field'    => 'slug',
+				'terms'    => $selected_attribute_terms,
+				'operator' => $tax_operator,
+			);
+		}
 
 		if ( ( ! isset( $excluded['min_price'] ) || ! isset( $excluded['max_price'] ) ) && isset( $filter_options['show_price'] ) && 'yes' === $filter_options['show_price'] ) {
 			$min_price = $this->get_request_decimal( 'min_price' );
@@ -1415,6 +1488,102 @@ final class ShopFilters {
 		wp_cache_set( $cache_key, $valid_terms, self::CACHE_GROUP, 300 );
 
 		return $valid_terms;
+	}
+
+	/**
+	 * Resolve filterable product attribute taxonomies excluding dedicated brand/color.
+	 *
+	 * @return array<int, string>
+	 */
+	private function get_filterable_attribute_taxonomies(): array {
+		if ( ! function_exists( 'wc_get_attribute_taxonomies' ) || ! function_exists( 'wc_attribute_taxonomy_name' ) ) {
+			return array();
+		}
+
+		$attribute_taxonomies = wc_get_attribute_taxonomies();
+		if ( empty( $attribute_taxonomies ) ) {
+			return array();
+		}
+
+		$resolved = array();
+		foreach ( $attribute_taxonomies as $attribute ) {
+			if ( ! is_object( $attribute ) || ! isset( $attribute->attribute_name ) ) {
+				continue;
+			}
+
+			$taxonomy = wc_attribute_taxonomy_name( (string) $attribute->attribute_name );
+			if ( ! taxonomy_exists( $taxonomy ) ) {
+				continue;
+			}
+
+			if ( $taxonomy === $this->brand_taxonomy || $taxonomy === $this->color_taxonomy ) {
+				continue;
+			}
+
+			$resolved[] = $taxonomy;
+		}
+
+		return array_values( array_unique( $resolved ) );
+	}
+
+	/**
+	 * Build request key for dynamic attribute taxonomy.
+	 *
+	 * @param string $taxonomy Taxonomy key.
+	 * @return string
+	 */
+	private function get_attribute_request_key( string $taxonomy ): string {
+		return 'wf_attr_' . sanitize_key( $taxonomy );
+	}
+
+	/**
+	 * Get display label for an attribute taxonomy.
+	 *
+	 * @param string $taxonomy Taxonomy key.
+	 * @return string
+	 */
+	private function get_attribute_display_label( string $taxonomy ): string {
+		$taxonomy_object = get_taxonomy( $taxonomy );
+		if ( $taxonomy_object instanceof \WP_Taxonomy && isset( $taxonomy_object->labels->singular_name ) && '' !== (string) $taxonomy_object->labels->singular_name ) {
+			return (string) $taxonomy_object->labels->singular_name;
+		}
+
+		return ucwords( str_replace( array( 'pa_', '_' ), array( '', ' ' ), $taxonomy ) );
+	}
+
+	/**
+	 * Determine whether taxonomy should render color swatches.
+	 *
+	 * @param string $taxonomy Taxonomy key.
+	 * @return bool
+	 */
+	private function is_color_like_taxonomy( string $taxonomy ): bool {
+		return $taxonomy === $this->color_taxonomy || false !== strpos( $taxonomy, 'color' );
+	}
+
+	/**
+	 * Resolve color swatch hex value from term metadata.
+	 *
+	 * @param \WP_Term $term Term object.
+	 * @return string
+	 */
+	private function get_term_color_hex( \WP_Term $term ): string {
+		$meta_keys = array( 'color', 'sw_color', 'product_attribute_color', 'attribute_pa_color' );
+		foreach ( $meta_keys as $meta_key ) {
+			$value = get_term_meta( $term->term_id, $meta_key, true );
+			if ( ! is_string( $value ) ) {
+				continue;
+			}
+
+			$color = sanitize_hex_color( $value );
+			if ( is_string( $color ) && '' !== $color ) {
+				return $color;
+			}
+		}
+
+		$name_color = sanitize_hex_color( (string) $term->name );
+
+		return is_string( $name_color ) ? $name_color : '';
 	}
 
 	/**

--- a/woo-filters.php
+++ b/woo-filters.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Woo Filters
  * Description: Shop/archive filters for WooCommerce.
- * Version: 0.10.0
+ * Version: 0.11.0
  * Author: Anisur Rahman
  * Author URI: https://github.com/anisur2805
  * Requires at least: 6.0


### PR DESCRIPTION
## Summary
- add dynamic filtering support for additional WooCommerce product attributes beyond brand/color
- auto-discover filterable attribute taxonomies during bootstrap and exclude dedicated brand/color blocks
- render each custom attribute as its own filter block with live counts and search support
- add color swatch rendering for color-like attributes using term meta hex values
- integrate custom attributes into active chips, clear-all behavior, shortcode query path, and main archive query path
- bump plugin version to 0.11.0

## Technical Details
- new discovery helper: filterable attribute taxonomy resolver
- dynamic request-key mapping per taxonomy (`wf_attr_{taxonomy}`)
- dynamic clause injection in both:
  - `get_request_filter_clauses()`
  - `get_shortcode_products_query()`
- enhanced term checkbox renderer with optional swatch mode
- added swatch UI class (`.wf-color-swatch`) for consistent frontend display

## Validation
- php syntax checks passed:
  - `php -l src/ShopFilters.php`
  - `php -l src/Plugin.php`
  - `php -l woo-filters.php`
- manual review completed for state persistence and URL arg handling

Closes #12