### PR TITLE
test: add automated coverage for query builder and filter state sync

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,11 @@
+{
+  "name": "anisur2805/woo-filters",
+  "description": "WooCommerce AJAX product filters",
+  "type": "wordpress-plugin",
+  "require-dev": {
+    "phpunit/phpunit": "^9.6"
+  },
+  "scripts": {
+    "test": "phpunit -c phpunit.xml.dist"
+  }
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+  bootstrap="tests/bootstrap.php"
+  colors="true"
+  beStrictAboutOutputDuringTests="true"
+  beStrictAboutTestsThatDoNotTestAnything="true"
+  failOnWarning="true"
+>
+  <testsuites>
+    <testsuite name="Woo Filters Unit Tests">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/tests/ShopFiltersQueryTest.php
+++ b/tests/ShopFiltersQueryTest.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Unit tests for query-clause and request-state normalization.
+ */
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use WooFilters\ShopFilters;
+
+final class ShopFiltersQueryTest extends TestCase {
+    /** @var ShopFilters */
+    private $subject;
+
+    protected function setUp(): void {
+        parent::setUp();
+        $_GET = array();
+
+        $this->subject = new ShopFilters('https://example.test/', 'test');
+        $this->setPrivateProperty('brand_taxonomy', 'pa_brand');
+        $this->setPrivateProperty('color_taxonomy', 'pa_color');
+        $this->invokePrivate('bootstrap_taxonomies');
+    }
+
+    protected function tearDown(): void {
+        $_GET = array();
+        parent::tearDown();
+    }
+
+    public function test_multiselect_mode_defaults_to_or(): void {
+        $mode = $this->invokePrivate('get_request_multiselect_mode');
+
+        self::assertSame('or', $mode);
+    }
+
+    public function test_multiselect_mode_accepts_and(): void {
+        $_GET['wf_logic'] = 'and';
+
+        $mode = $this->invokePrivate('get_request_multiselect_mode');
+
+        self::assertSame('and', $mode);
+    }
+
+    public function test_slug_list_is_normalized_and_deduplicated(): void {
+        $_GET['wf_brand'] = array('Apple', 'apple', 'ASUS', '');
+
+        $list = $this->invokePrivate('get_request_slug_list', 'wf_brand');
+
+        self::assertSame(array('apple', 'asus'), $list);
+    }
+
+    public function test_request_filter_clauses_use_and_operator_when_selected(): void {
+        $_GET['wf_logic'] = 'and';
+        $_GET['wf_brand'] = array('apple', 'asus');
+        $_GET['wf_color'] = array('red', 'blue');
+
+        $clauses = $this->invokePrivate('get_request_filter_clauses');
+        $tax = $clauses['tax'];
+
+        self::assertCount(2, $tax);
+        self::assertSame('AND', $tax[0]['operator']);
+        self::assertSame('AND', $tax[1]['operator']);
+    }
+
+    public function test_request_filter_clauses_include_dynamic_attribute_key(): void {
+        $_GET['wf_attr_pa_size'] = array('small', 'medium');
+
+        $clauses = $this->invokePrivate('get_request_filter_clauses');
+        $tax = $clauses['tax'];
+
+        self::assertNotEmpty($tax);
+        $found = false;
+        foreach ($tax as $clause) {
+            if (isset($clause['taxonomy']) && 'pa_size' === $clause['taxonomy']) {
+                $found = true;
+                self::assertSame(array('small', 'medium'), $clause['terms']);
+                self::assertSame('IN', $clause['operator']);
+            }
+        }
+
+        self::assertTrue($found);
+    }
+
+    public function test_current_query_args_strips_nonce_and_empty_values(): void {
+        $_GET['wf_nonce'] = 'abc';
+        $_GET['wf_brand'] = array('apple', '');
+        $_GET['paged'] = '2';
+        $_GET['_ignored'] = '1';
+
+        $args = $this->invokePrivate('get_current_query_args');
+
+        self::assertArrayHasKey('wf_brand', $args);
+        self::assertSame(array('apple'), $args['wf_brand']);
+        self::assertArrayHasKey('paged', $args);
+        self::assertArrayNotHasKey('wf_nonce', $args);
+        self::assertArrayNotHasKey('_ignored', $args);
+    }
+
+    /**
+     * @param string $method
+     * @param mixed  ...$args
+     * @return mixed
+     */
+    private function invokePrivate(string $method, ...$args) {
+        $reflection = new ReflectionMethod($this->subject, $method);
+        $reflection->setAccessible(true);
+        return $reflection->invokeArgs($this->subject, $args);
+    }
+
+    /**
+     * @param string $name
+     * @param mixed  $value
+     * @return void
+     */
+    private function setPrivateProperty(string $name, $value): void {
+        $reflection = new ReflectionProperty($this->subject, $name);
+        $reflection->setAccessible(true);
+        $reflection->setValue($this->subject, $value);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * PHPUnit bootstrap for lightweight unit tests.
+ */
+
+declare(strict_types=1);
+
+if (!defined('ABSPATH')) {
+    define('ABSPATH', __DIR__);
+}
+
+if (!function_exists('sanitize_key')) {
+    function sanitize_key(string $key): string {
+        $key = strtolower($key);
+        return (string) preg_replace('/[^a-z0-9_]/', '', $key);
+    }
+}
+
+if (!function_exists('sanitize_text_field')) {
+    function sanitize_text_field(string $value): string {
+        return trim(strip_tags($value));
+    }
+}
+
+if (!function_exists('sanitize_title')) {
+    function sanitize_title(string $value): string {
+        $value = strtolower(trim($value));
+        $value = (string) preg_replace('/[^a-z0-9_-]+/', '-', $value);
+        return trim($value, '-');
+    }
+}
+
+if (!function_exists('wp_unslash')) {
+    function wp_unslash(string $value): string {
+        return stripslashes($value);
+    }
+}
+
+if (!function_exists('wc_format_decimal')) {
+    function wc_format_decimal(string $value): string {
+        $normalized = str_replace(',', '.', $value);
+        if (!is_numeric($normalized)) {
+            return '';
+        }
+        return (string) $normalized;
+    }
+}
+
+if (!function_exists('absint')) {
+    function absint(string $value): int {
+        return abs((int) $value);
+    }
+}
+
+if (!function_exists('get_option')) {
+    function get_option(string $option, $default = false) {
+        return $default;
+    }
+}
+
+if (!function_exists('__')) {
+    function __(string $text, string $domain = ''): string {
+        return $text;
+    }
+}
+
+if (!function_exists('taxonomy_exists')) {
+    function taxonomy_exists(string $taxonomy): bool {
+        return in_array($taxonomy, array('pa_brand', 'pa_color', 'pa_size'), true);
+    }
+}
+
+if (!function_exists('wc_get_attribute_taxonomies')) {
+    function wc_get_attribute_taxonomies(): array {
+        return array(
+            (object) array('attribute_name' => 'brand'),
+            (object) array('attribute_name' => 'color'),
+            (object) array('attribute_name' => 'size'),
+        );
+    }
+}
+
+if (!function_exists('wc_attribute_taxonomy_name')) {
+    function wc_attribute_taxonomy_name(string $attribute): string {
+        return 'pa_' . sanitize_key($attribute);
+    }
+}
+
+require_once dirname(__DIR__) . '/src/FilterSettings.php';
+require_once dirname(__DIR__) . '/src/ShopFilters.php';


### PR DESCRIPTION
## Summary
- add PHPUnit test scaffold for plugin unit tests
- add deterministic bootstrap stubs to test request/query normalization methods without full WordPress bootstrap
- add focused unit tests for:
  - multi-select mode parsing
  - slug-list normalization and deduplication
  - dynamic attribute clause generation
  - AND/OR operator behavior in request clauses
  - query-arg sanitization and nonce stripping

## Files Added
- `composer.json` (dev dependency and test script)
- `phpunit.xml.dist`
- `tests/bootstrap.php`
- `tests/ShopFiltersQueryTest.php`

## Validation
- syntax checks passed for all test files and `src/ShopFilters.php`
- runtime test execution could not run in this environment because `phpunit` is not installed locally

Closes #6