### PR TITLE
security: enforce nonce checks on all filter query requests

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -41,7 +41,7 @@ final class Plugin {
 	 *
 	 * @var string
 	 */
-	private $version = '0.10.0';
+	private $version = '0.11.0';
 
 	/**
 	 * Shop filters service.

--- a/src/ShopFilters.php
+++ b/src/ShopFilters.php
@@ -1505,7 +1505,7 @@ final class ShopFilters {
 	 * @return bool
 	 */
 	private function is_valid_filter_request(): bool {
-		if ( ! $this->is_ajax_navigation_request() ) {
+		if ( ! $this->has_filter_query_args() ) {
 			return true;
 		}
 
@@ -1514,8 +1514,46 @@ final class ShopFilters {
 		}
 
 		$nonce = sanitize_text_field( wp_unslash( (string) $_GET['wf_nonce'] ) );
+		if ( strlen( $nonce ) < 8 ) {
+			return false;
+		}
 
-		return (bool) wp_verify_nonce( $nonce, self::NONCE_ACTION );
+		$verified = wp_verify_nonce( $nonce, self::NONCE_ACTION );
+
+		return 1 === $verified || 2 === $verified;
+	}
+
+	/**
+	 * Determine whether current request includes filter-bearing query args.
+	 *
+	 * @return bool
+	 */
+	private function has_filter_query_args(): bool {
+		$filter_keys = array(
+			'wf_cat',
+			'wf_brand',
+			'wf_color',
+			'wf_logic',
+			'min_price',
+			'max_price',
+			'rating_filter',
+			'wf_in_stock',
+			'wf_on_sale',
+		);
+
+		foreach ( $filter_keys as $key ) {
+			if ( isset( $_GET[ $key ] ) ) {
+				return true;
+			}
+		}
+
+		foreach ( $_GET as $key => $value ) {
+			if ( 0 === strpos( sanitize_key( (string) $key ), 'wf_attr_' ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/woo-filters.php
+++ b/woo-filters.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Woo Filters
  * Description: Shop/archive filters for WooCommerce.
- * Version: 0.10.0
+ * Version: 0.11.0
  * Author: Anisur Rahman
  * Author URI: https://github.com/anisur2805
  * Requires at least: 6.0


### PR DESCRIPTION
## Summary
- harden filter request validation so nonce checks apply to all filter-bearing requests (not only AJAX)
- add explicit filter-query detection with allowlisted keys and dynamic `wf_attr_*` support
- reject malformed short nonce values before verification
- keep non-filter requests unaffected
- bump plugin version to 0.11.0

## Technical Details
- `is_valid_filter_request()` now:
  - bypasses only when no filter params are present
  - requires `wf_nonce` for any request that includes filter args
  - verifies nonce and accepts valid WP nonce windows
- new helper: `has_filter_query_args()`
  - covers built-in filter keys and dynamic attribute filter keys

## Validation
- php syntax checks passed:
  - `php -l src/ShopFilters.php`
  - `php -l src/Plugin.php`
  - `php -l woo-filters.php`
- manual review completed for validation gate and request parsing behavior

Closes #21