### PR TITLE
feat: extend shortcode support with embed display controls

### DIFF
--- a/assets/css/wf-shop.css
+++ b/assets/css/wf-shop.css
@@ -17,6 +17,10 @@
   font-size: var(--wf-font-size);
 }
 
+.wf-shortcode-layout.wf-shortcode-no-sidebar {
+  grid-template-columns: 1fr;
+}
+
 .wf-filter-toggle,
 .wf-sidebar-overlay,
 .wf-sidebar-close {

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -41,7 +41,7 @@ final class Plugin {
 	 *
 	 * @var string
 	 */
-	private $version = '0.10.0';
+	private $version = '0.11.0';
 
 	/**
 	 * Shop filters service.

--- a/src/ShopFilters.php
+++ b/src/ShopFilters.php
@@ -254,8 +254,11 @@ final class ShopFilters {
 	public function render_shortcode( array $atts = array() ): string {
 		$atts = shortcode_atts(
 			array(
-				'per_page' => '12',
-				'columns'  => '4',
+				'per_page'        => '12',
+				'columns'         => '4',
+				'category'        => '',
+				'show_filters'    => 'yes',
+				'show_pagination' => 'yes',
 			),
 			$atts,
 			'woo_filters'
@@ -270,26 +273,36 @@ final class ShopFilters {
 		if ( $columns <= 0 || $columns > 6 ) {
 			$columns = 4;
 		}
+		$forced_category = sanitize_title( (string) $atts['category'] );
+		$show_filters    = $this->parse_shortcode_bool( (string) $atts['show_filters'], true );
+		$show_pagination = $this->parse_shortcode_bool( (string) $atts['show_pagination'], true );
 
 		$paged = max( 1, $this->get_request_absint( 'paged' ) );
 		if ( $paged <= 1 ) {
 			$paged = max( 1, $this->get_request_absint( 'product-page' ) );
 		}
 
-		$query = $this->get_shortcode_products_query( $per_page, $paged );
+		$query = $this->get_shortcode_products_query( $per_page, $paged, $forced_category );
 
 		$this->is_shortcode_context = true;
 		$this->shortcode_action_url = get_permalink();
 		$skin_class                 = $this->get_layout_skin_class();
 
 		ob_start();
-		echo '<div class="wf-shop-layout wf-shortcode-layout ' . esc_attr( $skin_class ) . '">';
-		echo '<button type="button" class="wf-filter-toggle" aria-expanded="false">' . esc_html__( 'Filters', 'woo-filters' ) . '</button>';
-		echo '<div class="wf-sidebar-overlay" aria-hidden="true"></div>';
-		echo '<aside class="wf-sidebar">';
-		echo '<button type="button" class="wf-sidebar-close" aria-label="' . esc_attr__( 'Close filters', 'woo-filters' ) . '">&times;</button>';
-		$this->render_filter_form();
-		echo '</aside>';
+		$layout_class = 'wf-shop-layout wf-shortcode-layout ' . $skin_class;
+		if ( ! $show_filters ) {
+			$layout_class .= ' wf-shortcode-no-sidebar';
+		}
+
+		echo '<div class="' . esc_attr( $layout_class ) . '">';
+		if ( $show_filters ) {
+			echo '<button type="button" class="wf-filter-toggle" aria-expanded="false">' . esc_html__( 'Filters', 'woo-filters' ) . '</button>';
+			echo '<div class="wf-sidebar-overlay" aria-hidden="true"></div>';
+			echo '<aside class="wf-sidebar">';
+			echo '<button type="button" class="wf-sidebar-close" aria-label="' . esc_attr__( 'Close filters', 'woo-filters' ) . '">&times;</button>';
+			$this->render_filter_form();
+			echo '</aside>';
+		}
 		echo '<section class="wf-products">';
 
 		if ( $query->have_posts() ) {
@@ -299,7 +312,9 @@ final class ShopFilters {
 				wc_get_template_part( 'content', 'product' );
 			}
 			echo '</ul>';
-			$this->render_shortcode_pagination( $query );
+			if ( $show_pagination ) {
+				$this->render_shortcode_pagination( $query );
+			}
 		} else {
 			$this->render_no_products_state();
 		}
@@ -777,11 +792,12 @@ final class ShopFilters {
 	/**
 	 * Build products query for shortcode context.
 	 *
-	 * @param int $per_page Products per page.
-	 * @param int $paged    Current page.
+	 * @param int    $per_page        Products per page.
+	 * @param int    $paged           Current page.
+	 * @param string $forced_category Optional forced category slug.
 	 * @return \WP_Query
 	 */
-	private function get_shortcode_products_query( int $per_page, int $paged ): \WP_Query {
+	private function get_shortcode_products_query( int $per_page, int $paged, string $forced_category = '' ): \WP_Query {
 		if ( ! $this->is_valid_filter_request() ) {
 			return new \WP_Query(
 				array(
@@ -806,6 +822,9 @@ final class ShopFilters {
 		$tax_operator = 'and' === $logic_mode ? 'AND' : 'IN';
 
 		$selected_category = $this->get_request_slug( 'wf_cat' );
+		if ( '' === $selected_category && '' !== $forced_category ) {
+			$selected_category = $forced_category;
+		}
 		if ( '' !== $selected_category ) {
 			$tax_clauses[] = array(
 				'taxonomy' => 'product_cat',
@@ -874,6 +893,30 @@ final class ShopFilters {
 		}
 
 		return new \WP_Query( $query_args );
+	}
+
+	/**
+	 * Parse shortcode yes/no-style boolean attribute.
+	 *
+	 * @param string $value   Raw value.
+	 * @param bool   $default Default value.
+	 * @return bool
+	 */
+	private function parse_shortcode_bool( string $value, bool $default ): bool {
+		$normalized = strtolower( trim( $value ) );
+		if ( '' === $normalized ) {
+			return $default;
+		}
+
+		if ( in_array( $normalized, array( '1', 'true', 'yes', 'on' ), true ) ) {
+			return true;
+		}
+
+		if ( in_array( $normalized, array( '0', 'false', 'no', 'off' ), true ) ) {
+			return false;
+		}
+
+		return $default;
 	}
 
 	/**

--- a/woo-filters.php
+++ b/woo-filters.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Woo Filters
  * Description: Shop/archive filters for WooCommerce.
- * Version: 0.10.0
+ * Version: 0.11.0
  * Author: Anisur Rahman
  * Author URI: https://github.com/anisur2805
  * Requires at least: 6.0


### PR DESCRIPTION
## Summary
- enhance `[woo_filters]` shortcode with embeddable display controls:
  - `category` (force initial category context)
  - `show_filters` (show/hide sidebar filter panel)
  - `show_pagination` (show/hide pagination)
- add no-sidebar layout mode for shortcode-only embeds
- keep existing AJAX filter behavior intact when sidebar is enabled
- bump plugin version to 0.11.0

## Technical Details
- `render_shortcode()` now parses and applies new shortcode attributes
- `get_shortcode_products_query()` now accepts forced category fallback when request category is not present
- added helper `parse_shortcode_bool()` for robust yes/no/true/false parsing
- CSS adds `.wf-shortcode-layout.wf-shortcode-no-sidebar` single-column layout support

## Validation
- php syntax checks passed:
  - `php -l src/ShopFilters.php`
  - `php -l src/Plugin.php`
  - `php -l woo-filters.php`
- manual code review completed for shortcode render branches and query behavior

Closes #14