### PR TITLE
chore: complete localization and text-domain bootstrapping

### DIFF
--- a/src/Analytics.php
+++ b/src/Analytics.php
@@ -392,8 +392,8 @@ final class Analytics {
 
 			foreach ( $values as $value => $count ) {
 				$rows[] = array(
-					'type'  => $this->humanize_key( (string) $type ),
-					'value' => $this->humanize_key( (string) $value ),
+					'type'  => $this->get_translated_filter_type_label( (string) $type ),
+					'value' => $this->get_translated_filter_value_label( (string) $value ),
 					'count' => absint( $count ),
 				);
 			}
@@ -432,7 +432,53 @@ final class Analytics {
 	}
 
 	/**
-	 * Humanize key for admin table output.
+	 * Get translated label for filter type key.
+	 *
+	 * @param string $type_key Filter type key.
+	 * @return string
+	 */
+	private function get_translated_filter_type_label( string $type_key ): string {
+		$labels = array(
+			'category'     => __( 'Category', 'woo-filters' ),
+			'brand'        => __( 'Brand', 'woo-filters' ),
+			'color'        => __( 'Color', 'woo-filters' ),
+			'logic'        => __( 'Logic', 'woo-filters' ),
+			'rating'       => __( 'Rating', 'woo-filters' ),
+			'min_price'    => __( 'Minimum Price', 'woo-filters' ),
+			'max_price'    => __( 'Maximum Price', 'woo-filters' ),
+			'availability' => __( 'Availability', 'woo-filters' ),
+		);
+
+		if ( isset( $labels[ $type_key ] ) ) {
+			return $labels[ $type_key ];
+		}
+
+		return $this->humanize_key( $type_key );
+	}
+
+	/**
+	 * Get translated label for filter value key.
+	 *
+	 * @param string $value_key Filter value key.
+	 * @return string
+	 */
+	private function get_translated_filter_value_label( string $value_key ): string {
+		$labels = array(
+			'in_stock' => __( 'In stock', 'woo-filters' ),
+			'on_sale'  => __( 'On sale', 'woo-filters' ),
+			'and'      => __( 'AND', 'woo-filters' ),
+			'or'       => __( 'OR', 'woo-filters' ),
+		);
+
+		if ( isset( $labels[ $value_key ] ) ) {
+			return $labels[ $value_key ];
+		}
+
+		return $this->humanize_key( $value_key );
+	}
+
+	/**
+	 * Humanize key fallback for admin table output.
 	 *
 	 * @param string $value Raw key.
 	 * @return string

--- a/woo-filters.php
+++ b/woo-filters.php
@@ -7,6 +7,8 @@
  * Author URI: https://github.com/anisur2805
  * Requires at least: 6.0
  * Requires PHP: 7.4
+ * Text Domain: woo-filters
+ * Domain Path: /languages
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -20,6 +22,8 @@ require_once __DIR__ . '/src/Autoloader.php';
 add_action(
 	'plugins_loaded',
 	static function () {
+		load_plugin_textdomain( 'woo-filters', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+
 		if ( ! class_exists( 'WooCommerce' ) ) {
 			return;
 		}


### PR DESCRIPTION
## Summary
- add plugin header i18n metadata (`Text Domain` and `Domain Path`) for translation discovery
- load plugin text domain during `plugins_loaded` for runtime localization support
- replace analytics table key humanization with translatable label maps for known filter types and values
- keep safe fallback formatting for unknown keys while preserving existing data behavior

## Quality checks
- php lint: woo-filters.php
- php lint: src/Analytics.php
- phpcs: not available in local environment (vendor/bin/phpcs missing)

Closes #20